### PR TITLE
Updates related to code walkthrough feedback

### DIFF
--- a/src/java/main/gov/nist/ucef/hla/base/FederateAmbassador.java
+++ b/src/java/main/gov/nist/ucef/hla/base/FederateAmbassador.java
@@ -130,11 +130,6 @@ public class FederateAmbassador extends NullFederateAmbassador
 		return this.federateTime;
 	}
 	
-	public void deleteObjectInstances()
-	{
-		this.federate.rtiamb.deleteObjectInstances( remoteHlaObjects.keySet() );	
-	}
-	
 	/////////////////////////////////////////////////////////////////////////////////////
 	// FederateAmbassador Callbacks     /////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////////////////////////////////
@@ -241,8 +236,7 @@ public class FederateAmbassador extends NullFederateAmbassador
 		{
 			// this is what *should* be happening - since it's a discovery, it 
 			// shouldn't be in the cache yet
-			Set<String> attributeNames = federate.subscribedObjectClassAttributeNames.get(objectClassHandle);
-			hlaObjectInstance = new HLAObject( objectInstanceHandle, attributeNames );
+			hlaObjectInstance = new HLAObject( objectInstanceHandle, null );
 			this.remoteHlaObjects.put( objectInstanceHandle, hlaObjectInstance );
 		}
 		this.federate.receiveObjectRegistration( hlaObjectInstance );
@@ -296,7 +290,7 @@ public class FederateAmbassador extends NullFederateAmbassador
 		}
 
 		// convert AttributeHandleValueMap to Map<String, byte[]> 
-		Map<String,byte[]> attributes = this.federate.convert( objectInstanceHandle, attributeMap );
+		Map<String,byte[]> attributes = federate.rtiamb.convert( objectInstanceHandle, attributeMap );
 		hlaObjectInstance.setState( attributes );
 
 		// do the appropriate callback on the federate
@@ -341,7 +335,7 @@ public class FederateAmbassador extends NullFederateAmbassador
 	    throws FederateInternalError
 	{
 		// convert ParameterHandleValueMap to Map<String, byte[]> 
-		Map<String,byte[]> parameters = this.federate.convert( interactionClassHandle, parameterMap );
+		Map<String,byte[]> parameters = federate.rtiamb.convert( interactionClassHandle, parameterMap );
 
 		// create the (transient) interaction
 		HLAInteraction interaction = new HLAInteraction( interactionClassHandle, parameters );

--- a/src/java/main/gov/nist/ucef/hla/base/FederateBase.java
+++ b/src/java/main/gov/nist/ucef/hla/base/FederateBase.java
@@ -20,23 +20,9 @@
  */
 package gov.nist.ucef.hla.base;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
-import hla.rti1516e.AttributeHandle;
-import hla.rti1516e.AttributeHandleSet;
-import hla.rti1516e.AttributeHandleValueMap;
-import hla.rti1516e.InteractionClassHandle;
-import hla.rti1516e.ObjectClassHandle;
-import hla.rti1516e.ObjectInstanceHandle;
-import hla.rti1516e.ParameterHandle;
-import hla.rti1516e.ParameterHandleValueMap;
 import hla.rti1516e.ResignAction;
-import hla.rti1516e.encoding.HLAfixedRecord;
 
 public abstract class FederateBase
 {
@@ -45,7 +31,6 @@ public abstract class FederateBase
 	//----------------------------------------------------------
 	private static final double MIN_TIME = 0.1;
 	private static final double MAX_TIME = 0.2;
-	private static final String NULL_TEXT = "NULL"; 
 	
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -55,19 +40,11 @@ public abstract class FederateBase
 	protected RTIAmbassadorWrapper rtiamb;
 	protected FederateAmbassador fedamb;
 	
-	// cache of object instances which we have registered with the RTI
-	protected Set<HLAObject> registeredObjects;
-	// a map allowing lookup of attribute names associated with object class handles
-	// as per the configured object class subscriptions
-	protected Map<ObjectClassHandle, Set<String>> subscribedObjectClassAttributeNames;
-	
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
 	protected FederateBase()
 	{
-		registeredObjects = new HashSet<>();
-		subscribedObjectClassAttributeNames = new HashMap<>();
 	}
 	
 	//----------------------------------------------------------
@@ -76,13 +53,13 @@ public abstract class FederateBase
 	////////////////////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////// Lifecycle Callback Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
-	public abstract void beforeFederationJoin();
-	public abstract void beforeReadyToPopulate();
-	public abstract void beforeReadyToRun();
-	public abstract void beforeFirstStep();
-	public abstract boolean step( double currentTime ); // == 0
-	public abstract void beforeReadyToResign();
-	public abstract void beforeExit();
+	protected abstract void beforeFederationJoin();
+	protected abstract void beforeReadyToPopulate();
+	protected abstract void beforeReadyToRun();
+	protected abstract void beforeFirstStep();
+	protected abstract boolean step( double currentTime ); // == 0
+	protected abstract void beforeReadyToResign();
+	protected abstract void beforeExit();
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////////////// RTI Callback Methods ///////////////////////////////////
@@ -118,12 +95,11 @@ public abstract class FederateBase
 
 		createAndJoinFederation();
 		enableTimePolicy();
+		
 		publishAndSubscribe();
 
 		beforeReadyToPopulate();
 		synchronize( UCEFSyncPoint.READY_TO_POPULATE );
-
-		registerObjects();
 
 		beforeReadyToRun();
 		synchronize( UCEFSyncPoint.READY_TO_RUN );
@@ -155,7 +131,6 @@ public abstract class FederateBase
 		synchronize( UCEFSyncPoint.READY_TO_RESIGN );
 		beforeExit();
 
-		deregisterObjects();
 		resignAndDestroyFederation();
 	}
 
@@ -163,8 +138,32 @@ public abstract class FederateBase
 	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/**
+	 * Create an interaction (with no parameter values)
+	 * 
+	 * @param className the name of the interaction class
+	 * @return the interaction
+	 */
+	protected HLAInteraction makeInteraction( String className )
+	{
+		return makeInteraction( className, null );
+	}
+	
+	/**
+	 * Create an interaction (with no parameter values)
+	 * 
+	 * @param className the name of the interaction class
+	 * @param parameters the parameters for the interaction (may be an empty map or null)
+	 * @return the interaction
+	 */
+	protected HLAInteraction makeInteraction( String className, Map<String, byte[]> parameters)
+	{
+		return rtiamb.makeInteraction( className, parameters );
+	}
+	
+	/**
 	 * Publish the provided interaction to the federation with a tag (which can be null).
 	 * 
+	 * @param interaction the interaction
 	 * @param tag the tag (can be null)
 	 */
 	protected void send( HLAInteraction interaction, byte[] tag )
@@ -176,6 +175,7 @@ public abstract class FederateBase
 	 * Publish the provided interaction to the federation with a tag (which can be null) and
 	 * time-stamp.
 	 * 
+	 * @param interaction the interaction
 	 * @param tag the tag (can be null)
 	 * @param time the time-stamp
 	 */
@@ -185,8 +185,41 @@ public abstract class FederateBase
 	}
 
 	/**
+	 * Create an object instance (with no initial values for the attributes), also registering the
+	 * instance with the RTI.
+	 * 
+	 * Refer to the {@link #deleteObjectInstance(HLAObject)} and
+	 * {@link #deleteObjectInstance(HLAObject, byte[])} for the symmetrical deletion methods.
+	 * 
+	 * @param className the name of the object class
+	 * @return the object instance
+	 */
+	protected HLAObject makeObjectInstance( String className )
+	{
+		return rtiamb.makeObjectInstance( className );
+	}
+	
+	/**
+	 * Create an object instance with initial values for the attributes, also registering the
+	 * instance with the RTI.
+	 * 
+	 * Refer to the {@link #deleteObjectInstance(HLAObject)} and
+	 * {@link #deleteObjectInstance(HLAObject, byte[])} for the symmetrical deletion methods.
+	 * 
+	 * @param className the name of the object class
+	 * @param initialValues the initial values for the object's attributes (may be an empty map or
+	 *            null)
+	 * @return the object instance
+	 */
+	protected HLAObject makeObjectInstance( String className, Map<String, byte[]> initialValues)
+	{
+		return rtiamb.makeObjectInstance( className, initialValues );
+	}
+	
+	/**
 	 * Update the provided instance out to the federation with a tag (which can be null).
 	 * 
+	 * @param instance the object instance
 	 * @param tag the tag (can be null)
 	 */
 	protected void update( HLAObject instance, byte[] tag )
@@ -198,6 +231,7 @@ public abstract class FederateBase
 	 * Update the provided instance out to the federation with a tag (which can be null) and
 	 * time-stamp.
 	 * 
+	 * @param instance the object instance
 	 * @param tag the tag (can be null)
 	 * @param time the time-stamp
 	 */
@@ -205,58 +239,39 @@ public abstract class FederateBase
 	{
 		rtiamb.updateAttributeValues( instance, tag, time );
 	}
+	
+	/**
+	 * This method will attempt to delete (i.e., de-register) the object instance from the RTI.
+	 * 
+	 * The object instance will most likely have been created in the first place by using the
+	 * {@link #makeObjectInstance(String)} or {@link #makeObjectInstance(String, Map)} method.
+	 * 
+	 * We can only delete objects we created, or for which we own the privilegeToDelete attribute.
+	 * 
+	 * @param instance the object instance
+	 * @return the deleted instance
+	 */
+	protected HLAObject deleteObjectInstance( HLAObject instance )
+	{
+		return deleteObjectInstance( instance, null );
+	}
 
 	/**
-	 * A utility method to allow simple instantiation of an interaction based off an interaction
-	 * name and some parameters
+	 * This method will attempt to delete (i.e., de-register) the object instance from the RTI.
 	 * 
-	 * @param name the interaction class name
-	 * @param parameters the parameters (can be null)
-	 * @return the interaction
+	 * The object instance will most likely have been created in the first place by using the
+	 * {@link #makeObjectInstance(String)} or {@link #makeObjectInstance(String, Map)} method.
+	 * 
+	 * We can only delete objects we created, or for which we own the privilegeToDelete attribute.
+	 * 
+	 * @param instance the object instance
+	 * @param tag the tag (can be null)
+	 * @return the deleted instance
 	 */
-	protected HLAInteraction makeInteraction( String name, Map<String,byte[]> parameters )
+	protected HLAObject deleteObjectInstance( HLAObject instance, byte[] tag )
 	{
-		return new HLAInteraction( rtiamb.getInteractionClassHandle( name ), parameters );
+		return rtiamb.deleteObjectInstance( instance, tag );
 	}
-	
-	/**
-	 * A utility method to encapsulate the code needed to convert a {@link AttributeHandleValueMap} into
-	 * a populated map containing attribute names and their associated byte values 
-	 * 
-	 * @param oih the object instance handle with which the attributes are associated
-	 * @param source the map containing attribute names and their associated byte values
-	 * @return a populated {@link Map}
-	 */
-	protected Map<String, byte[]> convert(ObjectInstanceHandle oih, AttributeHandleValueMap phvm)
-	{
-		ObjectClassHandle och = this.rtiamb.getKnownObjectClassHandle( oih );
-		HashMap<String,byte[]> result = new HashMap<>();
-		for( Entry<AttributeHandle,byte[]> entry : phvm.entrySet() )
-		{
-			String name = this.rtiamb.getAttributeName( och, entry.getKey() );
-			result.put( name, entry.getValue() );
-		}
-		return result;
-	}
-	
-	/**
-	 * A utility method to encapsulate the code needed to convert a {@link ParameterHandleValueMap} into
-	 * a populated map containing parameter names and their associated byte values 
-	 * 
-	 * @param ich the interaction class handle with which the parameters are associated
-	 * @param source the map containing parameter names and their associated byte values
-	 * @return a populated {@link Map}
-	 */
-	protected Map<String, byte[]> convert(InteractionClassHandle ich, ParameterHandleValueMap phvm)
-	{
-		HashMap<String,byte[]> result = new HashMap<>();
-		for( Entry<ParameterHandle,byte[]> entry : phvm.entrySet() )
-		{
-			String name = this.rtiamb.getParameterName( ich, entry.getKey() );
-			result.put( name, entry.getValue() );
-		}
-		return result;
-	}	
 
 	////////////////////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////// Internal Utility Methods /////////////////////////////////
@@ -292,7 +307,7 @@ public abstract class FederateBase
 	 * 
 	 * @param label the identifier of the synchronization point to synchronize to
 	 */
-	private void synchronize( String label )
+	protected void synchronize( String label )
 	{
 		// register the sync point
 		registerSyncPointAndWaitForAnnounce( label, null );
@@ -304,22 +319,10 @@ public abstract class FederateBase
 	 * Registers a synchronization point and waits for the announcement of that synchronization
 	 * point
 	 * 
-	 * @param syncPoint the UCEF standard synchronization point
-	 * @param tag a tag to go along with the synchronization point registration (may be null)
-	 */
-	protected void registerSyncPointAndWaitForAnnounce( UCEFSyncPoint syncPoint, byte[] tag )
-	{
-		registerSyncPointAndWaitForAnnounce(syncPoint.getLabel(), tag);
-	}
-	
-	/**
-	 * Registers a synchronization point and waits for the announcement of that synchronization
-	 * point
-	 * 
 	 * @param label the synchronization point label
 	 * @param tag a tag to go along with the synchronization point registration (may be null)
 	 */
-	private void registerSyncPointAndWaitForAnnounce( String label, byte[] tag )
+	protected void registerSyncPointAndWaitForAnnounce( String label, byte[] tag )
 	{
 		// Note that if the point already been registered, there will be a callback saying this
 		// failed, but as long as *someone* registered it everything is fine
@@ -334,20 +337,9 @@ public abstract class FederateBase
 	 * Achieves a synchronization point and waits for the federation to achieve that
 	 * synchronization point
 	 * 
-	 * @param syncPoint the UCEF standard synchronization point
-	 */
-	private void achieveSyncPointAndWaitForFederation( UCEFSyncPoint syncPoint )
-	{
-		achieveSyncPointAndWaitForFederation( syncPoint.getLabel() );
-	}
-
-	/**
-	 * Achieves a synchronization point and waits for the federation to achieve that
-	 * synchronization point
-	 * 
 	 * @param label the synchronization point label
 	 */
-	private void achieveSyncPointAndWaitForFederation( String label )
+	protected void achieveSyncPointAndWaitForFederation( String label )
 	{
 		rtiamb.synchronizationPointAchieved( label );
 		while( !fedamb.isAchieved( label ) )
@@ -389,7 +381,7 @@ public abstract class FederateBase
 	private void resignFromFederation( ResignAction resignAction )
 	{
 		if( resignAction == null )
-			resignAction = ResignAction.DELETE_OBJECTS;
+			resignAction = ResignAction.DELETE_OBJECTS_THEN_DIVEST;
 		
 		rtiamb.resignFederationExecution( resignAction );
 	}
@@ -423,336 +415,18 @@ public abstract class FederateBase
 		// no waiting for callbacks when disabling time policies
 		rtiamb.disableTimeConstrained();
 		fedamb.isTimeConstrained = false;
+		
 		rtiamb.disableTimeRegulation();
 		fedamb.isTimeRegulating = false;
 	}
 	
 	private void publishAndSubscribe()
 	{
-		publishObjectClassAttributes( configuration.getPublishedAttributes() );
-		subscribeObjectClassesAttributes( configuration.getSubscribedAttributes() );
-		publishInteractionClasses( configuration.getPublishedInteractions() );
-		subscribeInteractionClasses( configuration.getSubscribedInteractions() );
-	}
-
-	private void registerObjects()
-	{
-		// TODO this is just placeholder code which simply registers an instance for every 
-		//      published attribute entry in the configuration. It's possible that the
-		//      implementation might require single or multiple instances (or none, though
-		//      that would be pointless) on a per entry basis.
-		for(Entry<String,Set<String>> x : configuration.getPublishedAttributes().entrySet())
-		{
-			ObjectClassHandle classhandle = rtiamb.getObjectClassHandle( x.getKey() );
-			ObjectInstanceHandle instanceHandle = rtiamb.registerObjectInstance( classhandle );
-			registeredObjects.add( new HLAObject( instanceHandle, x.getValue() ) );
-		}
-	}
-	
-	private void deregisterObjects()
-	{
-		Set<HLAObject> deleted = new HashSet<>();
-		for( HLAObject obj : this.registeredObjects )
-		{
-			rtiamb.deleteObjectInstance( obj.getInstanceHandle(), null );
-			deleted.add( obj );
-		}
-		this.registeredObjects.removeAll( deleted );
-	}
-
-	/**
-	 * This method will inform the RTI about the types of interactions that the federate will be
-	 * publishing to the federation.
-	 */
-	private void publishInteractionClasses( Collection<String> interactionIDs)
-	{
-		if( interactionIDs == null || interactionIDs.isEmpty() )
-			return;
-
-		for( String interactionID : interactionIDs )
-			publishInteractionClass( interactionID );
-	}
-
-	/**
-	 * This method will inform the RTI about the types of interactions that the federate will be
-	 * publishing to the federation.
-	 */
-	private void publishInteractionClass( String className )
-	{
-		InteractionClassHandle handle = rtiamb.getInteractionClassHandle( className );
-		publishInteractionClass( handle );
-	}
-	
-	/**
-	 * This method will inform the RTI about the an interaction that a federate will be publishing to 
-	 * the federation.
-	 */
-	private void publishInteractionClass(InteractionClassHandle handle)
-	{
-		if( handle == null )
-			throw new UCEFException( "NULL interaction class handle. Cannot publish interaction class." );
-
-		try
-		{
-			rtiamb.publishInteractionClass( handle );
-		}
-		catch( Exception e )
-		{
-			throw new UCEFException( e, "Failed to publish interaction class with handle %s", 
-			                         makeSummary( handle ) );
-		}
-	}
-	
-	/**
-	 * This method will inform the RTI about the types of attributes the federate will be
-	 * publishing to the federation, and to which classes they belong.
-	 * 
-	 * This needs to be done before registering instances of the object classes and updating their
-	 * attributes' values 
-	 */
-	private void publishObjectClassAttributes( Map<String,Set<String>> publishedAttributes)
-	{
-		if(publishedAttributes == null || publishedAttributes.isEmpty())
-			return;
-
-		for( Entry<String,Set<String>> publication : publishedAttributes.entrySet() )
-		{
-			String className = publication.getKey();
-			ObjectClassHandle classHandle = rtiamb.getObjectClassHandle( className );
-			if( classHandle == null )
-			{
-				throw new UCEFException( "Unknown object class name '%s'. Cannot publish attributes.",
-				                         className );
-			}
-			
-			AttributeHandleSet attributeHandleSet = rtiamb.makeAttributeHandleSet();
-			for( String attributeName : publication.getValue() )
-			{
-				AttributeHandle attributeHandle = rtiamb.getAttributeHandle( classHandle, attributeName );
-				if( classHandle == null )
-				{
-					throw new UCEFException( "Unknown attribute name '%s'. Cannot publish attributes " +
-											 "for object class %s.",
-					                         attributeName , makeSummary( classHandle ) );
-				}
-				attributeHandleSet.add( attributeHandle );
-			}
-			
-			publishObjectClassAttributes( classHandle, attributeHandleSet );
-		}
-	}
-	
-	/**
-	 * This method will inform the RTI about the types of attributes the federate will be
-	 * publishing to the federation, and to which classes they belong.
-	 * 
-	 * This needs to be done before registering instances of the object classes and updating their
-	 * attributes' values 
-	 */
-	private void publishObjectClassAttributes(ObjectClassHandle handle, AttributeHandleSet attributes)
-	{
-		if( handle == null )
-			throw new UCEFException( "NULL object class handle. Cannot publish object class atributes." );
-
-		if( attributes == null )
-			throw new UCEFException( "NULL attribute handle set. Cannot publish attributes for object " +
-									 "class %s.",
-			                         makeSummary( handle ) );
-			
-		try
-		{
-			rtiamb.publishObjectClassAttributes( handle, attributes );
-		}
-		catch( Exception e )
-		{
-			throw new UCEFException( e,
-			                         "Failed to publish object class atributes for object class %s.",
-			                         makeSummary( handle ) );
-		}
-	}
-	
-	/**
-	 * This method will inform the RTI about the types of interactions that the federate will be
-	 * interested in hearing about as other federates produce them.
-	 */
-	private void subscribeInteractionClasses( Collection<String> interactionClassNames )
-	{
-		if( interactionClassNames == null || interactionClassNames.isEmpty() )
-			return;
-
-		for( String interactionClassName : interactionClassNames )
-		{
-			subscribeInteractionClass( interactionClassName );
-		}
-	}
-	
-	/**
-	 * This method will inform the RTI about a class of interaction that a federate will subscribe to 
-	 * 
-	 * @param className the name of the interaction class to subscribe to
-	 */
-	private void subscribeInteractionClass( String className )
-	{
-		InteractionClassHandle handle = rtiamb.getInteractionClassHandle( className );
-
-		if( handle == null )
-		{
-			throw new UCEFException( "Cannot subscribe to interaction class using unknown class " +
-									 "name '%s'.",
-			                         className );
-		}
-
-		subscribeInteractionClass( handle );
-	}
-	
-	/**
-	 * This method will inform the RTI about a class of interaction that a federate will subscribe to 
-	 * 
-	 * @param handle the handle of the interaction class to subscribe to
-	 */
-	private void subscribeInteractionClass( InteractionClassHandle handle )
-	{
-		if( handle == null )
-			throw new UCEFException( "NULL interaction class handle. Cannot subscribe to " +
-									 "interaction class." );
-
-		try
-		{
-			rtiamb.subscribeInteractionClass( handle );
-		}
-		catch( Exception e )
-		{
-			throw new UCEFException( e,
-			                         "Failed to subscribe to interaction class %s",
-			                         makeSummary( handle ) );
-		}
-	}
-	
-	/**
-	 * This method will inform the RTI about the types of attributes the federate will be
-	 * interested in hearing about, and to which classes they belong.
-	 * 
-	 * We need to subscribe to hear about information on attributes of classes created and altered
-	 * in other federates
-	 * 
-	 * @param subscribedAttributes a map which connects object class names to sets of attribute
-	 *            names to be subscribed to
-	 */
-	private void subscribeObjectClassesAttributes( Map<String,Set<String>> subscribedAttributes)
-	{
-		if(subscribedAttributes == null || subscribedAttributes.isEmpty())
-			return;
-
-		for( Entry<String,Set<String>> subscription : subscribedAttributes.entrySet() )
-		{
-			// get all the handle information for the attributes of the current class
-			String className = subscription.getKey();
-			ObjectClassHandle classHandle = rtiamb.getObjectClassHandle( className );
-			if( classHandle == null )
-			{
-				throw new UCEFException( "Unknown object class name '%s'. Cannot subscribe to attributes.",
-				                         className );
-			}
-			// package the information into the handle set
-			AttributeHandleSet attributeHandleSet = rtiamb.makeAttributeHandleSet();
-			for( String attributeName : subscription.getValue() )
-			{
-				AttributeHandle attributeHandle = rtiamb.getAttributeHandle( classHandle, attributeName );
-				if( attributeHandle == null )
-				{
-					throw new UCEFException( "Unknown attribute name '%s'. Cannot subscribe to " +
-											 "attributes for object class %s.",
-					                         attributeName , makeSummary( classHandle ));
-				}
-				attributeHandleSet.add( attributeHandle );
-			}
-			subscribedObjectClassAttributeNames.put( classHandle, subscription.getValue() );
-			
-			// do the actual subscription
-			subscribeObjectClassAttributes( classHandle, attributeHandleSet );
-		}
-	}
-	
-	/**
-	 * This method will inform the RTI about the types of attributes the federate will be
-	 * publishing to the federation, and which class they are associated with.
-	 * 
-	 * This needs to be done before registering instances of the object classes and updating their
-	 * attributes' values
-	 * 
-	 * @param handle the handle for the object class whose attributes are to be subscribed to
-	 * @param attributes the attribute handles identifying the attributes to be subscribed to
-	 */
-	private void subscribeObjectClassAttributes(ObjectClassHandle handle, AttributeHandleSet attributes)
-	{
-		if( handle == null )
-			throw new UCEFException( "NULL object class handle. Cannot subscribe to attributes." );
-
-		if( attributes == null )
-			throw new UCEFException( "NULL attribute handle set . Cannot subscribe to attributes for " +
-									 "object class %s.",
-			                         makeSummary( handle ) );
-
-		try
-		{
-			rtiamb.subscribeObjectClassAttributes( handle, attributes );
-		}
-		catch( Exception e )
-		{
-			throw new UCEFException( e,
-			                         "Failed to subscribe to object class attributes for object class %s.",
-			                         makeSummary( handle ) );
-		}
-	}
-	
-	/**
-	 * This is a utility method simply to construct a human readable summary of an object
-	 * class's salient details for the purposes of populating exception text
-	 * 
-	 * @param handle the object class handle
-	 * @return the descriptive text
-	 */
-	private String makeSummary(ObjectClassHandle handle)
-	{
-		String className = NULL_TEXT;
-		try
-		{
-			className = rtiamb.getObjectClassName( handle );
-		}
-		catch(Exception e)
-		{
-			// ignore any problems here
-		}
+		rtiamb.publishObjectClassAttributes( configuration.getPublishedAttributes() );
+		rtiamb.publishInteractionClasses( configuration.getPublishedInteractions() );
 		
-		StringBuilder details = new StringBuilder( "'" + className + "'" );
-		details.append( " (handle'" + (handle==null?NULL_TEXT:handle) + "')" );
-		
-		return details.toString();
-	}
-	
-	/**
-	 * This is a utility method simply to construct a human readable summary of an interaction
-	 * class's salient details for the purposes of populating exception text
-	 * 
-	 * @param handle the interaction class handle
-	 * @return the descriptive text
-	 */
-	private String makeSummary(InteractionClassHandle handle)
-	{
-		String className = NULL_TEXT;
-		try
-		{
-			className = rtiamb.getInteractionClassName( handle );
-		}
-		catch(Exception e)
-		{
-			// ignore any problems here
-		}
-		
-		StringBuilder details = new StringBuilder( "'" + className + "'" );
-		details.append( " (handle'" + (handle==null?NULL_TEXT:handle) + "')" );
-		
-		return details.toString();
+		rtiamb.subscribeObjectClassesAttributes( configuration.getSubscribedAttributes() );
+		rtiamb.subscribeInteractionClasses( configuration.getSubscribedInteractions() );
 	}
 
 	//----------------------------------------------------------

--- a/src/java/main/gov/nist/ucef/hla/base/HLAInteraction.java
+++ b/src/java/main/gov/nist/ucef/hla/base/HLAInteraction.java
@@ -51,12 +51,34 @@ public class HLAInteraction
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	public HLAInteraction( InteractionClassHandle interactionClassHandle,
-	                       Map<String, byte[]> parameters )
+	/**
+	 * Construct a new interaction instance with no parameter values
+	 * 
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeInteraction() method should be used
+	 * to create a new {@link HLAInteraction}
+	 * 
+	 * @param interactionClassHandle the class handle to which this instance corresponds
+	 */
+	protected HLAInteraction( InteractionClassHandle interactionClassHandle )
+	{
+		this( interactionClassHandle, null );
+	}
+
+	/**
+	 * Construct a new interaction instance with parameter values
+	 * 
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeInteraction() method should be used
+	 * to create a new {@link HLAInteraction}
+	 * 
+	 * @param interactionClassHandle the class handle to which this instance corresponds
+	 * @param parameters the parameter values for the interaction (may be empty or null)
+	 */
+	protected HLAInteraction( InteractionClassHandle interactionClassHandle,
+	                          Map<String,byte[]> parameters )
 	{
 		this.interactionClassHandle = interactionClassHandle;
 		this.parameters = parameters == null ? new HashMap<>() : parameters;
-		
+
 		this.encoder = HLACodecUtils.getEncoder();
 	}
 
@@ -83,7 +105,7 @@ public class HLAInteraction
 	 * Obtain the underlying HLA handle associated with this interaction
 	 * @return the underlying HLA handle associated with this interaction
 	 */
-	public InteractionClassHandle getInteractionClassHandle()
+	protected InteractionClassHandle getInteractionClassHandle()
 	{
 		return this.interactionClassHandle;
 	}
@@ -100,7 +122,7 @@ public class HLAInteraction
 	}
 	
 	/**
-	 * Determine if the named parameter has been initialised (i.e. has a value)
+	 * Determine if the named parameter has been initialized (i.e. has a value)
 	 * 
 	 * In practice, this means that the byte array value associated with the 
 	 * named parameter is: 
@@ -110,7 +132,7 @@ public class HLAInteraction
 	 * @param parameterName the name of the attribute
 	 * @return true if the parameter as a value defined for it, false otherwise
 	 */
-	public boolean isInitialised( String parameterName )
+	public boolean isInitialized( String parameterName )
 	{
 		byte[] rawValue = getRawValue( parameterName );
 		return rawValue != null && rawValue.length != 0;

--- a/src/java/main/gov/nist/ucef/hla/base/HLAObject.java
+++ b/src/java/main/gov/nist/ucef/hla/base/HLAObject.java
@@ -38,7 +38,6 @@ public class HLAObject
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
-	private static final byte[] EMPTY_BYTE_ARRAY = {};
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -52,26 +51,35 @@ public class HLAObject
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	public HLAObject( ObjectInstanceHandle objectInstanceHandle, Collection<String> attributeNames )
+	/**
+	 * Construct a new object instance with no attribute values
+	 * 
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjetInstance() method should be
+	 * used to create a new {@link HLAObject}
+	 * 
+	 * @param interactionClassHandle the class handle to which this instance corresponds
+	 */
+	protected HLAObject( ObjectInstanceHandle objectInstanceHandle )
+	{
+		this( objectInstanceHandle, null );
+	}
+
+	/**
+	 * Construct a new object instance with attribute values
+	 * 
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjetInstance() method should be
+	 * used to create a new {@link HLAObject}
+	 * 
+	 * @param interactionClassHandle the class handle to which this instance corresponds
+	 * @param initialValues the initial attribute values for the interaction (may be empty or
+	 *            null)
+	 */
+	protected HLAObject( ObjectInstanceHandle objectInstanceHandle,
+	                     Map<String,byte[]> initialValues )
 	{
 		this.objectInstanceHandle = objectInstanceHandle;
-		this.attributes = new HashMap<>();
-		// sanity check for null attribute names - since an object instance with no attributes wouldn't
-		// be very useful, possibly we should throw an exception here...? There's nothing inherently
-		// "illegal" about it though, it's just pointless.
-		if(attributeNames != null)
-		{
-			// TODO Here we initialise each attribute with an empty/zero-length byte array - this 
-			//      essentially means that the attributes are all "uninitialised", since even an 
-			//      empty string would require a single byte '\0' (null terminator) character. Any
-			//      attempt to retrieve a "typed" value at this stage will result in an HLA 
-			//      decoding error (see the isInitialised() method). 
-			//      In future we should probably initialise each attribute with at least a sensible 
-			//      default value for primitive types at least (e.g., 0 for integers, 0.0 for floats,
-			//      false for booleans, etc) but for now this is sufficient.
-			attributeNames.forEach( (attrName) -> this.attributes.put( attrName, EMPTY_BYTE_ARRAY) );
-		}
-		
+		this.attributes = initialValues == null ? new HashMap<>() : initialValues;
+
 		this.encoder = HLACodecUtils.getEncoder();
 	}
 	
@@ -95,7 +103,7 @@ public class HLAObject
 	 * Obtain the underlying HLA handle associated with this instance
 	 * @return the underlying HLA handle associated with this instance
 	 */
-	public ObjectInstanceHandle getInstanceHandle()
+	protected ObjectInstanceHandle getInstanceHandle()
 	{
 		return this.objectInstanceHandle;
 	}

--- a/src/java/main/gov/nist/ucef/hla/base/RTIAmbassadorWrapper.java
+++ b/src/java/main/gov/nist/ucef/hla/base/RTIAmbassadorWrapper.java
@@ -22,8 +22,10 @@ package gov.nist.ucef.hla.base;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import hla.rti1516e.AttributeHandle;
 import hla.rti1516e.AttributeHandleSet;
@@ -233,7 +235,7 @@ public class RTIAmbassadorWrapper
 		}
 	}
 
-	public void destroyFederationExecution(FederateConfiguration configuration)
+	public void destroyFederationExecution( FederateConfiguration configuration )
 	{
 		try
 		{
@@ -259,36 +261,52 @@ public class RTIAmbassadorWrapper
 	}
 
 	/**
-	 * This method will attempt to delete the object instances with the given handles. We can only
+	 * This method will attempt to delete the object instance with the given handle. We can only
 	 * delete objects we created, or for which we own the privilegeToDelete attribute.
+	 * 
+	 * @param instance the object instance
 	 */
-	public void deleteObjectInstances( Collection<ObjectInstanceHandle> handles )
+	public void deleteObjectInstance( HLAObject instance )
 	{
-		for( ObjectInstanceHandle handle : handles )
+		deleteObjectInstance( instance, null );
+	}
+
+	/**
+	 * This method will attempt to delete the object instance. We can only delete objects we
+	 * created, or for which we own the privilegeToDelete attribute.
+	 * 
+	 * @param instance the object instance
+	 * @param tag the tag (may be null)
+	 * @return the deleted instance
+	 */
+	public HLAObject deleteObjectInstance( HLAObject instance, byte[] tag )
+	{
+		if( instance == null )
 		{
-			try
-			{
-				rtiAmbassador.deleteObjectInstance( handle, EMPTY_BYTE_ARRAY );
-			}
-			catch( DeletePrivilegeNotHeld e )
-			{
-				// We catch and deliberately ignore this exception - this is not an error 
-				// condition as such, it just means that the permission to delete this instance
-				// is held by someone else, so we have to let them clean it up.
-			}
-			catch( Exception e)
-			{
-				throw new UCEFException(e, "Unable to delete object instance %s", makeSummary( handle ));
-			}
+			throw new UCEFException( "%s object instance. Unable to delete object instance.",
+			                         NULL_TEXT );
 		}
-	}	
-	
+
+		deleteObjectInstance( instance.getInstanceHandle(), tag );
+		
+		return instance;
+	}
+
 	/**
 	 * This method will attempt to delete the object instance with the given handle. We can only
 	 * delete objects we created, or for which we own the privilegeToDelete attribute.
+	 * 
+	 * @param handle the handle of the object instance
+	 * @param tag the tag (may be null)
 	 */
-	public void deleteObjectInstance( ObjectInstanceHandle handle, byte[] tag )
+	private void deleteObjectInstance( ObjectInstanceHandle handle, byte[] tag )
 	{
+		if( handle == null )
+		{
+			throw new UCEFException( "%s object instance handle. Unable to delete object instance.",
+			                         NULL_TEXT );
+		}
+		
 		try
 		{
 			rtiAmbassador.deleteObjectInstance( handle, safeByteArray( tag ) );
@@ -694,7 +712,8 @@ public class RTIAmbassadorWrapper
 	{
 		if( handle == null )
 		{
-			throw new UCEFException( "NULL object class handle. Cannot register object instance." );
+			throw new UCEFException( "%s object class handle. Cannot register object instance.", 
+			                         NULL_TEXT );
 		}
 		
 		ObjectInstanceHandle instanceHandle = null;
@@ -730,16 +749,94 @@ public class RTIAmbassadorWrapper
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
+	//////////////////////// INTERACTION AND OBJECT INSTANCE CREATION //////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * A utility method to allow simple instantiation of an no-parameter interaction based off an 
+	 * interaction class name
+	 * 
+	 * @param name the interaction class name
+	 * @return the interaction
+	 */
+	public HLAInteraction makeInteraction( String name )
+	{
+		return makeInteraction( name, null );
+	}
+	
+	/**
+	 * A utility method to allow simple instantiation of an interaction based off an interaction
+	 * name and some parameters
+	 * 
+	 * @param name the interaction class name
+	 * @param parameters the parameters (can be null)
+	 * @return the interaction
+	 */
+	public HLAInteraction makeInteraction( String name, Map<String,byte[]> parameters )
+	{
+		return new HLAInteraction( getInteractionClassHandle( name ), parameters );
+	}
+
+	/**
+	 * A utility method to allow simple instantiation of an object instance based off an object class 
+	 * name and some initial values for the attributes, also registering the instance with the RTI. 
+	 * 
+	 * @param name the object class name
+	 * @return the interaction
+	 */
+	public HLAObject makeObjectInstance( String className )
+	{
+		return makeObjectInstance( className, null );
+	}
+	
+	/**
+	 * A utility method to allow simple instantiation of an object instance based off an object class 
+	 * name and some initial values for the attributes, also registering the instance with the RTI.
+	 * 
+	 * @param name the object class name
+	 * @param initialValues the initial values for the attributes (can be null)
+	 * @return the interaction
+	 */
+	public HLAObject makeObjectInstance( String className, Map<String,byte[]> initialValues )
+	{
+		ObjectClassHandle classhandle = getObjectClassHandle( className );
+		ObjectInstanceHandle instanceHandle = registerObjectInstance( classhandle );
+		return new HLAObject( instanceHandle, initialValues );
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////// PUBLISH AND SUBSCRIBE REGISTRATION /////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/**
-	 * This method will inform the RTI about the an interaction that a federate will be publishing to 
-	 * the federation.
+	 * This method will inform the RTI about the types of interactions that the federate will be
+	 * publishing to the federation.
 	 */
-	public void publishInteractionClass(InteractionClassHandle handle)
+	public void publishInteractionClasses( Collection<String> classNames)
+	{
+		if( classNames == null || classNames.isEmpty() )
+			return;
+
+		for( String className : classNames )
+			publishInteractionClass( className );
+	}
+
+	/**
+	 * This method will inform the RTI about the types of interactions that the federate will be
+	 * publishing to the federation.
+	 */
+	private void publishInteractionClass( String className )
+	{
+		publishInteractionClass( getInteractionClassHandle( className ) );
+	}
+	
+	/**
+	 * This method will inform the RTI about the an interaction that a federate will be publishing
+	 * to the federation.
+	 */
+	private void publishInteractionClass( InteractionClassHandle handle )
 	{
 		if( handle == null )
-			throw new UCEFException( "NULL interaction class handle. Cannot publish interaction class." );
+			throw new UCEFException( "%s interaction class handle. Cannot publish interaction class.",
+			                         NULL_TEXT );
 
 		try
 		{
@@ -747,7 +844,7 @@ public class RTIAmbassadorWrapper
 		}
 		catch( Exception e )
 		{
-			throw new UCEFException( e, "Failed to publish interaction class with handle %s", 
+			throw new UCEFException( e, "Failed to publish interaction class with handle %s",
 			                         makeSummary( handle ) );
 		}
 	}
@@ -759,15 +856,56 @@ public class RTIAmbassadorWrapper
 	 * This needs to be done before registering instances of the object classes and updating their
 	 * attributes' values 
 	 */
-	public void publishObjectClassAttributes(ObjectClassHandle handle, AttributeHandleSet attributes)
+	public void publishObjectClassAttributes( Map<String,Set<String>> publishedAttributes)
+	{
+		if(publishedAttributes == null || publishedAttributes.isEmpty())
+			return;
+
+		for( Entry<String,Set<String>> publication : publishedAttributes.entrySet() )
+		{
+			String className = publication.getKey();
+			ObjectClassHandle classHandle = getObjectClassHandle( className );
+			if( classHandle == null )
+			{
+				throw new UCEFException( "Unknown object class name '%s'. Cannot publish attributes.",
+				                         className );
+			}
+			
+			AttributeHandleSet attributeHandleSet = makeAttributeHandleSet();
+			for( String attributeName : publication.getValue() )
+			{
+				AttributeHandle attributeHandle = getAttributeHandle( classHandle, attributeName );
+				if( classHandle == null )
+				{
+					throw new UCEFException( "Unknown attribute name '%s'. Cannot publish attributes " +
+											 "for object class %s.",
+					                         attributeName , makeSummary( classHandle ) );
+				}
+				attributeHandleSet.add( attributeHandle );
+			}
+			
+			publishObjectClassAttributes( classHandle, attributeHandleSet );
+		}
+	}
+	
+	/**
+	 * This method will inform the RTI about the types of attributes the federate will be
+	 * publishing to the federation, and to which classes they belong.
+	 * 
+	 * This needs to be done before registering instances of the object classes and updating their
+	 * attributes' values
+	 */
+	private void publishObjectClassAttributes( ObjectClassHandle handle,
+	                                           AttributeHandleSet attributes )
 	{
 		if( handle == null )
-			throw new UCEFException( "NULL object class handle. Cannot publish object class atributes." );
+			throw new UCEFException( "%s object class handle. Cannot publish object class atributes.",
+			                         NULL_TEXT );
 
 		if( attributes == null )
-			throw new UCEFException( "NULL attribute handle set. Cannot publish attributes for object class %s.",
-			                         makeSummary( handle ) );
-			
+			throw new UCEFException( "%s attribute handle set. Cannot publish attributes for object " +
+			                         "class %s.", NULL_TEXT, makeSummary( handle ) );
+
 		try
 		{
 			rtiAmbassador.publishObjectClassAttributes( handle, attributes );
@@ -781,14 +919,49 @@ public class RTIAmbassadorWrapper
 	}
 	
 	/**
+	 * This method will inform the RTI about the types of interactions that the federate will be
+	 * interested in hearing about as other federates produce them.
+	 */
+	public void subscribeInteractionClasses( Collection<String> interactionClassNames )
+	{
+		if( interactionClassNames == null || interactionClassNames.isEmpty() )
+			return;
+
+		for( String interactionClassName : interactionClassNames )
+		{
+			subscribeInteractionClass( interactionClassName );
+		}
+	}
+	
+	/**
+	 * This method will inform the RTI about a class of interaction that a federate will subscribe to 
+	 * 
+	 * @param className the name of the interaction class to subscribe to
+	 */
+	private void subscribeInteractionClass( String className )
+	{
+		InteractionClassHandle handle = getInteractionClassHandle( className );
+
+		if( handle == null )
+		{
+			throw new UCEFException( "Cannot subscribe to interaction class using unknown class " +
+									 "name '%s'.",
+			                         className );
+		}
+
+		subscribeInteractionClass( handle );
+	}
+	
+	/**
 	 * This method will inform the RTI about a class of interaction that a federate will subscribe to 
 	 * 
 	 * @param handle the handle of the interaction class to subscribe to
 	 */
-	public void subscribeInteractionClass( InteractionClassHandle handle )
+	private void subscribeInteractionClass( InteractionClassHandle handle )
 	{
 		if( handle == null )
-			throw new UCEFException( "NULL interaction class handle. Cannot subscribe to interaction class." );
+			throw new UCEFException( "%s interaction class handle. Cannot subscribe to " +
+									 "interaction class.", NULL_TEXT );
 
 		try
 		{
@@ -804,6 +977,50 @@ public class RTIAmbassadorWrapper
 	
 	/**
 	 * This method will inform the RTI about the types of attributes the federate will be
+	 * interested in hearing about, and to which classes they belong.
+	 * 
+	 * We need to subscribe to hear about information on attributes of classes created and altered
+	 * in other federates
+	 * 
+	 * @param subscribedAttributes a map which connects object class names to sets of attribute
+	 *            names to be subscribed to
+	 */
+	public void subscribeObjectClassesAttributes( Map<String,Set<String>> subscribedAttributes )
+	{
+		if( subscribedAttributes == null || subscribedAttributes.isEmpty() )
+			return;
+
+		for( Entry<String,Set<String>> subscription : subscribedAttributes.entrySet() )
+		{
+			// get all the handle information for the attributes of the current class
+			String className = subscription.getKey();
+			ObjectClassHandle classHandle = getObjectClassHandle( className );
+			if( classHandle == null )
+			{
+				throw new UCEFException( "Unknown object class name '%s'. Cannot subscribe to attributes.",
+				                         className );
+			}
+			// package the information into the handle set
+			AttributeHandleSet attributeHandleSet = makeAttributeHandleSet();
+			for( String attributeName : subscription.getValue() )
+			{
+				AttributeHandle attributeHandle = getAttributeHandle( classHandle, attributeName );
+				if( attributeHandle == null )
+				{
+					throw new UCEFException( "Unknown attribute name '%s'. Cannot subscribe to " +
+					                         "attributes for object class %s.", attributeName,
+					                         makeSummary( classHandle ) );
+				}
+				attributeHandleSet.add( attributeHandle );
+			}
+
+			// do the actual subscription
+			subscribeObjectClassAttributes( classHandle, attributeHandleSet );
+		}
+	}
+	
+	/**
+	 * This method will inform the RTI about the types of attributes the federate will be
 	 * publishing to the federation, and which class they are associated with.
 	 * 
 	 * This needs to be done before registering instances of the object classes and updating their
@@ -812,14 +1029,16 @@ public class RTIAmbassadorWrapper
 	 * @param handle the handle for the object class whose attributes are to be subscribed to
 	 * @param attributes the attribute handles identifying the attributes to be subscribed to
 	 */
-	public void subscribeObjectClassAttributes(ObjectClassHandle handle, AttributeHandleSet attributes)
+	private void subscribeObjectClassAttributes( ObjectClassHandle handle,
+	                                             AttributeHandleSet attributes )
 	{
 		if( handle == null )
-			throw new UCEFException( "NULL object class handle. Cannot subscribe to attributes." );
+			throw new UCEFException( "%s object class handle. Cannot subscribe to attributes.",
+			                         NULL_TEXT );
 
 		if( attributes == null )
-			throw new UCEFException( "NULL attribute handle set . Cannot subscribe to attributes for object class %s.",
-			                         makeSummary( handle ) );
+			throw new UCEFException( "%s attribute handle set . Cannot subscribe to attributes for " +
+			                         "object class %s.", NULL_TEXT, makeSummary( handle ) );
 
 		try
 		{
@@ -831,7 +1050,7 @@ public class RTIAmbassadorWrapper
 			                         "Failed to subscribe to object class attributes for object class %s.",
 			                         makeSummary( handle ) );
 		}
-	}	
+	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
 	////////////////////////////////////// PUBLICATION /////////////////////////////////////////
@@ -851,7 +1070,8 @@ public class RTIAmbassadorWrapper
 	{
 		// basic sanity checks on provided arguments
 		if( instance == null )
-			throw new UCEFException( "NULL object instance. Cannot update attribute values." );
+			throw new UCEFException( "%s object instance. Cannot update attribute values.",
+			                         NULL_TEXT );
 		
 		ObjectInstanceHandle objectInstanceHandle = instance.getInstanceHandle();
 		try
@@ -888,7 +1108,8 @@ public class RTIAmbassadorWrapper
 	{
 		// basic sanity checks on provided arguments
 		if( interaction == null )
-			throw new UCEFException( "NULL interaction. Cannot send interaction." );
+			throw new UCEFException( "%s interaction. Cannot send interaction.",
+			                         NULL_TEXT );
 		
 		InteractionClassHandle interactionClassHandle = interaction.getInteractionClassHandle();
 		try
@@ -916,7 +1137,7 @@ public class RTIAmbassadorWrapper
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
-	/////////////////////////////// Internal Utility Methods ///////////////////////////////////
+	/////////////////////////////////// Utility Methods ////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/**
 	 * A utility method to convert a map containing parameter names and their associated byte
@@ -926,7 +1147,7 @@ public class RTIAmbassadorWrapper
 	 * @param source the map containing parameter names and their associated byte values
 	 * @return a populated {@link ParameterHandleValueMap}
 	 */
-	private ParameterHandleValueMap convert( InteractionClassHandle ich, Map<String,byte[]> source )
+	protected ParameterHandleValueMap convert( InteractionClassHandle ich, Map<String,byte[]> source )
 	{
 		ParameterHandleValueMap result = parameterMapFactory.create( source.size() );
 		for( Entry<String,byte[]> entry : source.entrySet() )
@@ -949,7 +1170,7 @@ public class RTIAmbassadorWrapper
 	 * @param source the map containing attribute names and their associated byte values
 	 * @return a populated {@link AttributeHandleValueMap}
 	 */
-	private AttributeHandleValueMap convert( ObjectInstanceHandle oih, Map<String,byte[]> source )
+	protected AttributeHandleValueMap convert( ObjectInstanceHandle oih, Map<String,byte[]> source )
 	{
 		ObjectClassHandle och = getKnownObjectClassHandle( oih );
 		AttributeHandleValueMap result = attributeMapFactory.create( source.size() );
@@ -966,14 +1187,67 @@ public class RTIAmbassadorWrapper
 	}
 	
 	/**
+	 * A utility method to encapsulate the code needed to convert a
+	 * {@link AttributeHandleValueMap} into a populated map containing attribute names and their
+	 * associated byte values
+	 * 
+	 * @param oih the object instance handle with which the attributes are associated
+	 * @param source the map containing attribute names and their associated byte values
+	 * @return a populated {@link Map}
+	 */
+	protected Map<String,byte[]> convert( ObjectInstanceHandle oih, AttributeHandleValueMap phvm )
+	{
+		ObjectClassHandle och = getKnownObjectClassHandle( oih );
+		HashMap<String,byte[]> result = new HashMap<>();
+		for( Entry<AttributeHandle,byte[]> entry : phvm.entrySet() )
+		{
+			String name = getAttributeName( och, entry.getKey() );
+			result.put( name, entry.getValue() );
+		}
+		return result;
+	}
+
+	/**
+	 * A utility method to encapsulate the code needed to convert a
+	 * {@link ParameterHandleValueMap} into a populated map containing parameter names and their
+	 * associated byte values
+	 * 
+	 * @param ich the interaction class handle with which the parameters are associated
+	 * @param source the map containing parameter names and their associated byte values
+	 * @return a populated {@link Map}
+	 */
+	protected Map<String,byte[]> convert( InteractionClassHandle ich, ParameterHandleValueMap phvm )
+	{
+		HashMap<String,byte[]> result = new HashMap<>();
+		for( Entry<ParameterHandle,byte[]> entry : phvm.entrySet() )
+		{
+			String name = getParameterName( ich, entry.getKey() );
+			result.put( name, entry.getValue() );
+		}
+		return result;
+	}
+	
+	/**
 	 * A utility method to provide an zero-length byte array in place of a null as required
 	 * 
 	 * @param byteArray the byte array
 	 * @return the original byte array if it is not null, or a zero length byte array otherwise
 	 */
-	private byte[] safeByteArray( byte[] byteArray )
+	public byte[] safeByteArray( byte[] byteArray )
 	{
 		return byteArray == null ? EMPTY_BYTE_ARRAY : byteArray;
+	}
+	
+	/**
+	 * A utility method purely for the purpose of constructing meaningful text for error messages
+	 * regarding object instances
+	 * 
+	 * @param instance the object
+	 * @return the details of the object
+	 */
+	public String makeSummary( HLAObject instance )
+	{
+		return makeSummary( instance.getInstanceHandle() );
 	}
 	
 	/**
@@ -983,11 +1257,11 @@ public class RTIAmbassadorWrapper
 	 * @param handle the object instance handle
 	 * @return the details of the associated object instance
 	 */
-	public String makeSummary(ObjectInstanceHandle handle)
+	private String makeSummary( ObjectInstanceHandle handle )
 	{
 		String instanceName = NULL_TEXT;
 		ObjectClassHandle classHandle = null;
-	
+
 		try
 		{
 			instanceName = getObjectInstanceName( handle );
@@ -1005,11 +1279,14 @@ public class RTIAmbassadorWrapper
 		{
 			// ignore - null is OK as a result here
 		}
-		
-		StringBuilder details = new StringBuilder( "'" + (instanceName==null?NULL_TEXT:instanceName) + "' " );
-		details.append( "(handle '" + (handle==null?NULL_TEXT:handle) + "') of object class " );
+
+		StringBuilder details =
+		    new StringBuilder( "'" + (instanceName == null ? NULL_TEXT : instanceName) + "' " );
+		details.append(
+		                "(handle '" + (handle == null ? NULL_TEXT : handle) +
+		                "') of object class " );
 		details.append( makeSummary( classHandle ) );
-		
+
 		return details.toString();
 	}
 
@@ -1020,7 +1297,7 @@ public class RTIAmbassadorWrapper
 	 * @param handle the object class handle
 	 * @return the details of the associated object class
 	 */
-	public String makeSummary(ObjectClassHandle handle)
+	private String makeSummary( ObjectClassHandle handle )
 	{
 		String className = NULL_TEXT;
 		try
@@ -1031,11 +1308,24 @@ public class RTIAmbassadorWrapper
 		{
 			// ignore - null is OK as a result here
 		}
-		
-		StringBuilder details = new StringBuilder( "'" + (className==null?NULL_TEXT:className) + "' " );
-		details.append( "(handle '" + (handle==null?NULL_TEXT:handle) + "')" );
-		
+
+		StringBuilder details =
+		    new StringBuilder( "'" + (className == null ? NULL_TEXT : className) + "' " );
+		details.append( "(handle '" + (handle == null ? NULL_TEXT : handle) + "')" );
+
 		return details.toString();
+	}
+
+	/**
+	 * A utility method purely for the purpose of constructing meaningful text for error messages
+	 * regarding interactions
+	 * 
+	 * @param interaction the interaction
+	 * @return the details of the interaction
+	 */
+	public String makeSummary( HLAInteraction interaction )
+	{
+		return makeSummary( interaction.getInteractionClassHandle() );
 	}
 	
 	/**
@@ -1045,7 +1335,7 @@ public class RTIAmbassadorWrapper
 	 * @param handle the interaction class handle
 	 * @return the details of the associated interaction class
 	 */
-	public String makeSummary(InteractionClassHandle handle)
+	private String makeSummary( InteractionClassHandle handle )
 	{
 		String className = NULL_TEXT;
 		try
@@ -1056,10 +1346,11 @@ public class RTIAmbassadorWrapper
 		{
 			// ignore - null is OK as a result here
 		}
-		
-		StringBuilder details = new StringBuilder( "'" + (className==null?NULL_TEXT:className) + "' " );
-		details.append( "(handle '" + (handle==null?NULL_TEXT:handle) + "')" );
-		
+
+		StringBuilder details =
+		    new StringBuilder( "'" + (className == null ? NULL_TEXT : className) + "' " );
+		details.append( "(handle '" + (handle == null ? NULL_TEXT : handle) + "')" );
+
 		return details.toString();
 	}
 	


### PR DESCRIPTION
 - Updates to make the constructors for HLAObject and HLAInteraction consistent, and related changes to other code.
 - MyFederate and FederateBase now have almost no requirement to import anything from the 'hla.rti1516e' package - eveyrthing of consequence is Strings and byte[]s except where absolutely required.
 - Moved several utility methods from FederateBase to RTIAmbassadorWrapper (or provided neater wrapper methods in FederateBase for commnly used functions).
 - Fixed and ammended commenting.