### PR TITLE
Remove Smart HLAObjects RTIAmbassador Constructor Parameter

### DIFF
--- a/src/java/.classpath
+++ b/src/java/.classpath
@@ -12,6 +12,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="D:/dev/workspaces/UCEF_CALYTRIX/federate-base/external/java/lib/portico/2.1.0/portico.jar" sourcepath="D:/dev/workspaces/PORTICO/portico/codebase/src/java/portico"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/3"/>
+	<classpathentry kind="lib" path="D:/dev/workspaces/UCEF_CALYTRIX/federate-base/lib/java/lib/portico-master.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/java/main/gov/nist/ucef/hla/base/HLAInteraction.java
+++ b/src/java/main/gov/nist/ucef/hla/base/HLAInteraction.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import hla.rti1516e.InteractionClassHandle;
 import hla.rti1516e.encoding.EncoderFactory;
 
 /**
@@ -46,7 +45,7 @@ public class HLAInteraction
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
-	protected InteractionClassHandle interactionClassHandle;
+	protected final String interactionClassName;
 	protected Map<String, byte[]> parameters;
 	
 	// used for encoding/decoding byte array representations of interaction parameters
@@ -63,9 +62,9 @@ public class HLAInteraction
 	 * 
 	 * @param interactionClassHandle the class handle to which this instance corresponds
 	 */
-	protected HLAInteraction( InteractionClassHandle interactionClassHandle )
+	protected HLAInteraction( String interactionClassName )
 	{
-		this( interactionClassHandle, null );
+		this( interactionClassName, null );
 	}
 
 	/**
@@ -77,10 +76,10 @@ public class HLAInteraction
 	 * @param interactionClassHandle the class handle to which this instance corresponds
 	 * @param parameters the parameter values for the interaction (may be empty or null)
 	 */
-	protected HLAInteraction( InteractionClassHandle interactionClassHandle,
+	protected HLAInteraction( String interactionClassName,
 	                          Map<String,byte[]> parameters )
 	{
-		this.interactionClassHandle = interactionClassHandle;
+		this.interactionClassName = interactionClassName;
 		this.parameters = parameters == null ? new HashMap<>() : parameters;
 
 		this.encoder = HLACodecUtils.getEncoder();
@@ -98,7 +97,7 @@ public class HLAInteraction
 	 */
 	protected HLAInteraction( HLAInteraction interaction )
 	{
-		this.interactionClassHandle = interaction.interactionClassHandle;
+		this.interactionClassName = interaction.interactionClassName;
 		this.parameters = interaction.parameters;
 		
 		this.encoder = interaction.encoder;
@@ -117,19 +116,19 @@ public class HLAInteraction
 	public int hashCode()
 	{
 		// delegate to the cached interaction class handle
-		return this.interactionClassHandle.hashCode();
+		return this.interactionClassName.hashCode();
 	}
-
+	
     ////////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Obtain the underlying HLA interaction class handle associated with this instance
-	 * @return the underlying HLA interaction class associated with this instance
+	 * Obtain the underlying HLA interaction class name associated with this instance
+	 * @return the underlying HLA interaction name associated with this instance
 	 */
-	protected InteractionClassHandle getInteractionClassHandle()
+	public String getInteractionClassName()
 	{
-		return this.interactionClassHandle;
+		return this.interactionClassName;
 	}
 	
 	/**

--- a/src/java/main/gov/nist/ucef/hla/base/HLAObject.java
+++ b/src/java/main/gov/nist/ucef/hla/base/HLAObject.java
@@ -46,11 +46,12 @@ public class HLAObject
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
-	private ObjectInstanceHandle objectInstanceHandle;
-	private Map<String, byte[]> attributes;
+	protected final String objectClassName;
+	protected Map<String, byte[]> attributes;
+	protected ObjectInstanceHandle instanceHandle;
 	
 	// used for encoding/decoding byte array representations of attributes
-	private EncoderFactory encoder;
+	protected EncoderFactory encoder;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -58,31 +59,61 @@ public class HLAObject
 	/**
 	 * Construct a new object instance with no attribute values
 	 * 
-	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjetInstance() method should be
-	 * used to create a new {@link HLAObject}
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjectInstance() family of methods
+	 * should be used to create a new {@link HLAObject}
 	 * 
 	 * @param interactionClassHandle the class handle to which this instance corresponds
 	 */
-	protected HLAObject( ObjectInstanceHandle objectInstanceHandle )
+	protected HLAObject( String objectClassName )
 	{
-		this( objectInstanceHandle, null );
+		this( objectClassName, null, null );
+	}
+	
+	/**
+	 * Construct a new object instance with no attribute values
+	 * 
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjectInstance() family of methods
+	 * should be used to create a new {@link HLAObject}
+	 * 
+	 * @param interactionClassHandle the class handle to which this instance corresponds
+	 */
+	protected HLAObject( String objectClassName, ObjectInstanceHandle handle )
+	{
+		this( objectClassName, null, handle );
 	}
 
 	/**
 	 * Construct a new object instance with attribute values
 	 * 
-	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjetInstance() method should be
-	 * used to create a new {@link HLAObject}
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjectInstance() family of methods
+	 * should be used to create a new {@link HLAObject}
 	 * 
 	 * @param interactionClassHandle the class handle to which this instance corresponds
 	 * @param initialValues the initial attribute values for the interaction (may be empty or
 	 *            null)
 	 */
-	protected HLAObject( ObjectInstanceHandle objectInstanceHandle,
-	                     Map<String,byte[]> initialValues )
+	protected HLAObject( String objectClassName, Map<String,byte[]> initialValues )
 	{
-		this.objectInstanceHandle = objectInstanceHandle;
+		this( objectClassName, initialValues, null );
+	}
+	
+	/**
+	 * Construct a new object instance with attribute values
+	 * 
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjectInstance() family of methods
+	 * should be used to create a new {@link HLAObject}
+	 * 
+	 * @param interactionClassHandle the class handle to which this instance corresponds
+	 * @param initialValues the initial attribute values for the interaction (may be empty or
+	 *            null)
+	 */
+	protected HLAObject( String objectClassName,
+	                     Map<String,byte[]> initialValues, ObjectInstanceHandle handle )
+	{
+		this.objectClassName = objectClassName;
 		this.attributes = initialValues == null ? new HashMap<>() : initialValues;
+		
+		this.instanceHandle = handle;
 
 		this.encoder = HLACodecUtils.getEncoder();
 	}
@@ -92,16 +123,18 @@ public class HLAObject
 	 * 
 	 * NOTE: this will result in an instance which is "linked" to the original instance.
 	 * 
-	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeInteraction() method should be used
-	 * to create a new {@link HLAObject}
+	 * NOTE: Generally speaking the RTIAmbassadorWrapper's makeObjectInstance() family of methods
+	 * should be used to create a new {@link HLAObject}
 	 * 
 	 * @param objectInstance the object instance to use as the base
 	 */
 	protected HLAObject( HLAObject objectInstance )
 	{
-		this.objectInstanceHandle = objectInstance.objectInstanceHandle;
+		this.objectClassName = objectInstance.objectClassName;
 		this.attributes = objectInstance.attributes;
 		
+		this.instanceHandle = objectInstance.instanceHandle;
+
 		this.encoder = objectInstance.encoder;
 	}
 	
@@ -115,7 +148,7 @@ public class HLAObject
 	public int hashCode()
 	{
 		// delegate to the cached object instance handle
-		return this.objectInstanceHandle.hashCode();
+		return this.objectClassName.hashCode();
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
@@ -125,9 +158,19 @@ public class HLAObject
 	 * Obtain the underlying HLA handle associated with this instance
 	 * @return the underlying HLA handle associated with this instance
 	 */
-	protected ObjectInstanceHandle getInstanceHandle()
+	public String getObjectClassName()
 	{
-		return this.objectInstanceHandle;
+		return this.objectClassName;
+	}
+	
+	/**
+	 * Returns the unique instance handle of this HLA object.
+	 *
+	 * @return the unique instance handle of this HLA object.
+	 */
+	public ObjectInstanceHandle getObjectInstanceHandle()
+	{
+		return this.instanceHandle;
 	}
 	
 	/**

--- a/src/java/main/gov/nist/ucef/hla/base/Types.java
+++ b/src/java/main/gov/nist/ucef/hla/base/Types.java
@@ -1,0 +1,131 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.base;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Types
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/**
+	 * Represents an attribute in an object class in a Simulation Object Model
+	 *
+	 * @see ObjectClass
+	 */
+	protected static class ObjectAttribute
+	{
+		public String name;
+		public boolean publish;
+		public boolean subscribe;
+
+		public ObjectAttribute( String name )
+		{
+			this.name = name;
+			this.publish = false;
+			this.subscribe = false;
+		}
+	}
+
+	/**
+	 * Represents an object class in a Simulation Object Model
+	 *
+	 * @see SOMParser#getObjectClasses(string&)
+	 * @see ObjectAttribute
+	 */
+	protected static class ObjectClass
+	{
+		public String name; // fully qualified object class name
+		public boolean publish;
+		public boolean subscribe;
+		Map<String,ObjectAttribute> attributes;
+
+		public ObjectClass( String name )
+		{
+			this.name = name;
+			this.publish = false;
+			this.subscribe = false;
+			this.attributes = new HashMap<>();
+		}
+	}
+
+	/**
+	 * Represents a parameter in an interaction class in a Simulation Object Model
+	 *
+	 * @see InteractionClass
+	 */
+	protected static class InteractionParameter
+	{
+		public String name;
+
+		public InteractionParameter( String name )
+		{
+			this.name = name;
+		}
+	}
+
+	/**
+	 * Represents an interaction class in a Simulation Object Model
+	 *
+	 * @see SOMParser#getInteractionClasses(string&)
+	 * @see InteractionParameter
+	 */
+	protected static class InteractionClass
+	{
+		public String name; // fully qualified interaction class name
+		public boolean publish;
+		public boolean subscribe;
+		public Map<String,InteractionParameter> parameters;
+
+		public InteractionClass( String name )
+		{
+			this.name = name;
+			this.publish = false;
+			this.subscribe = false;
+			this.parameters = new HashMap<>();
+		}
+	}
+}

--- a/src/java/main/gov/nist/ucef/hla/base/UCEFSyncPoint.java
+++ b/src/java/main/gov/nist/ucef/hla/base/UCEFSyncPoint.java
@@ -105,7 +105,21 @@ public enum UCEFSyncPoint
 		//       chronological order
 		return other != null && this.ordinal() < other.ordinal();
 	}
-
+	
+	/**
+	 * Determine if this synchronization point is at or before the provided synchronization point
+	 * 
+	 * @param other the other synchronization point
+	 * @return true if this synchronization point is at or before the provided synchronization
+	 *         point, false otherwise
+	 */
+	public boolean isAtOrBefore( UCEFSyncPoint other )
+	{
+		// NOTE: relies on the enumerated values being defined in the expected 
+		//       chronological order
+		return other != null && this.ordinal() <= other.ordinal();
+	}
+	
 	/**
 	 * Determine if this synchronization point is after the provided synchronization point
 	 * 
@@ -121,14 +135,43 @@ public enum UCEFSyncPoint
 	}
 
 	/**
+	 * Determine if this synchronization point is at or after the provided synchronization point
+	 * 
+	 * @param other the other synchronization point
+	 * @return true if this synchronization point is at or after the provided synchronization
+	 *         point, false otherwise
+	 */
+	public boolean isAtOrAfter( UCEFSyncPoint other )
+	{
+		// NOTE: relies on the enumerated values being defined in the expected 
+		//       chronological order
+		return other != null && this.ordinal() >= other.ordinal();
+	}
+	
+	/**
+	 * Determine if this synchronization point is the same as the provided synchronization point
+	 * 
+	 * NOTE: this is just wrapper around the standard enumeration equals() method provided to
+	 * improve code readability
+	 * 
+	 * @param other the other synchronization point
+	 * @return true if this synchronization point is the same as the provided synchronization
+	 *         point, false otherwise
+	 */
+	public boolean is( UCEFSyncPoint other )
+	{
+		return this.equals( other );
+	}
+
+	/**
 	 * Determine if this synchronization point is not the same as the provided synchronization
 	 * point
 	 * 
-	 * NOTE: this is just a negatiion of the standard enumeration equals() method provided to
-	 * improve code readbility
+	 * NOTE: this is just a negation of the standard enumeration equals() method provided to
+	 * improve code readability
 	 * 
 	 * @param other the other synchronization point
-	 * @return true if this synchronization point not the same as the provided synchronization
+	 * @return true if this synchronization point is not the same as the provided synchronization
 	 *         point, false otherwise
 	 */
 	public boolean isNot( UCEFSyncPoint other )

--- a/src/java/main/gov/nist/ucef/hla/example/base/PingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/base/PingFederate.java
@@ -157,7 +157,7 @@ public class PingFederate extends FederateBase
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		String interactionName = rtiamb.getInteractionClassName( hlaInteraction );
+		String interactionName = hlaInteraction.getInteractionClassName();
 		if( PONG_INTERACTION_ID.equals( interactionName ) )
 		{
 			// Pong interaction received

--- a/src/java/main/gov/nist/ucef/hla/example/base/PongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/base/PongFederate.java
@@ -157,7 +157,7 @@ public class PongFederate extends FederateBase
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		String interactionName = rtiamb.getInteractionClassName( hlaInteraction );
+		String interactionName = hlaInteraction.getInteractionClassName();
 		if( PING_INTERACTION_ID.equals( interactionName ) )
 		{
 			// Ping interaction received

--- a/src/java/main/gov/nist/ucef/hla/example/fedman/FedManFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/fedman/FedManFederate.java
@@ -356,7 +356,7 @@ public class FedManFederate extends NoOpFederate
 	 */
 	private void sendSimPause()
 	{
-		sendInteraction( new SimPause( rtiamb ) );
+		sendInteraction( new SimPause() );
 	}
 	
 	/**
@@ -365,7 +365,7 @@ public class FedManFederate extends NoOpFederate
 	 */
 	private void sendSimResume()
 	{
-		sendInteraction( new SimResume( rtiamb ) );
+		sendInteraction( new SimResume() );
 	}
 	
 	/**
@@ -374,7 +374,7 @@ public class FedManFederate extends NoOpFederate
 	 */
 	private void sendSimEnd()
 	{
-		sendInteraction( new SimEnd( rtiamb ) );
+		sendInteraction( new SimEnd() );
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/java/main/gov/nist/ucef/hla/example/fedman/FederationManager.java
+++ b/src/java/main/gov/nist/ucef/hla/example/fedman/FederationManager.java
@@ -127,7 +127,7 @@ public class FederationManager
 		{
 			String fomRootPath = "resources/foms/";
 			// modules
-			String[] moduleFoms = { fomRootPath + "FederationManager.xml", 
+			String[] moduleFoms = { fomRootPath + "FederationManager.xml",
 			                        fomRootPath + "SmartPingPong.xml" };
 			config.addModules( FileUtils.urlsFromPaths(moduleFoms) );
 			

--- a/src/java/main/gov/nist/ucef/hla/example/noopbase/NoOpPingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/noopbase/NoOpPingFederate.java
@@ -106,8 +106,8 @@ public class NoOpPingFederate extends NoOpFederate
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		String interactionName = rtiamb.getInteractionClassName( hlaInteraction );
-		if( PONG_INTERACTION_ID.equals( interactionName ) )
+		String interactionClassName = hlaInteraction.getInteractionClassName( );
+		if( PONG_INTERACTION_ID.equals( interactionClassName ) )
 		{
 			// Pong interaction received
 			if( hlaInteraction.isPresent( PONG_PARAM_LETTER ) )
@@ -125,7 +125,7 @@ public class NoOpPingFederate extends NoOpFederate
 		{
 			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
 			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
-			                                    interactionName ) );
+			                                    interactionClassName ) );
 		}
 	}
 

--- a/src/java/main/gov/nist/ucef/hla/example/noopbase/NoOpPongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/noopbase/NoOpPongFederate.java
@@ -106,8 +106,8 @@ public class NoOpPongFederate extends NoOpFederate
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		String interactionName = rtiamb.getInteractionClassName( hlaInteraction );
-		if( PING_INTERACTION_ID.equals( interactionName ) )
+		String interactionClassName = hlaInteraction.getInteractionClassName();
+		if( PING_INTERACTION_ID.equals( interactionClassName ) )
 		{
 			// Ping interaction received
 			if( hlaInteraction.isPresent( PING_PARAM_COUNT ) )
@@ -125,7 +125,7 @@ public class NoOpPongFederate extends NoOpFederate
 		{
 			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
 			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
-			                                    interactionName ) );
+			                                    interactionClassName ) );
 		}
 	}
 

--- a/src/java/main/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
@@ -86,14 +86,14 @@ public class SmartPingFederate extends _SmartPingFederate
 	public void beforeFirstStep()
 	{
 		this.count =  0;
-		this.player = new Player( rtiamb, "PingPlayer" );
+		this.player = register( new Player() );
 	}
 
 	@Override
 	public boolean step( double currentTime )
 	{
 		// here we end out our interaction and attribute update
-		sendInteraction( new Ping( rtiamb, this.count ) );
+		sendInteraction( new Ping().count(  this.count ) );
 		updateAttributeValues( this.player );
 		// update the values
 		this.count++;
@@ -115,7 +115,7 @@ public class SmartPingFederate extends _SmartPingFederate
 	protected void receivePongInteraction( Pong pong )
 	{
 		System.out.println( String.format( "Received Pong interaction - letter is '%s'.",
-		                                   pong.letter() ) );
+		                                   pong.isLetterPresent() ? pong.letter() : "UNDEFINED" ) );
 	}
 
 	/**
@@ -127,7 +127,7 @@ public class SmartPingFederate extends _SmartPingFederate
 	protected void receivePlayerUpdate( Player player )
 	{
 		System.out.println( String.format( "Received Player update - name is %s",
-		                                   player.name() ) );
+		                                   player.isNamePresent() ? player.name() : "UNDEFINED" ) );
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/java/main/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
@@ -85,18 +85,18 @@ public class SmartPongFederate extends _SmartPongFederate
 	public void beforeFirstStep()
 	{
 		this.letter = 'a';
-		this.player = new Player( rtiamb, "PongPlayer" );
+		this.player = register( new Player() );
 	}
 
 	@Override
 	public boolean step( double currentTime )
 	{
 		// here we end out our interaction and attribute update
-		sendInteraction( new Pong( rtiamb, this.letter ) );
+		sendInteraction( new Pong().letter( this.letter ) );
 		updateAttributeValues( this.player );
 		// update the values
 		this.letter++;
-		String nextPlayerName = this.player.name() + this.letter;
+		String nextPlayerName = (this.player.isNamePresent() ? this.player.name() : "") + this.letter;
 		this.player.name( nextPlayerName );
 		// keep going until time 10.0
 		return (currentTime < 10.0);
@@ -108,25 +108,25 @@ public class SmartPongFederate extends _SmartPongFederate
 	/**
 	 * Handle receipt of a {@link Ping}
 	 * 
-	 * @param interaction the interaction to handle
+	 * @param ping the interaction to handle
 	 */
 	@Override
-	protected void receivePingInteraction( Ping interaction )
+	protected void receivePingInteraction( Ping ping )
 	{
 		System.out.println( String.format( "Received Ping interaction - count is %s",
-		                                   interaction.count() ) );
+		                                   ping.isCountPresent() ? ping.count() : "UNDEFINED" ) );
 	}
 
 	/**
 	 * Handle receipt of a {@link Player}
 	 * 
-	 * @param obj the object to handle
+	 * @param player the object to handle
 	 */
 	@Override
-	protected void receivePlayerUpdate( Player obj )
+	protected void receivePlayerUpdate( Player player )
 	{
 		System.out.println( String.format( "Received Player update - name is %s",
-		                                   obj.name() ) );
+		                                   player.isNamePresent() ? player.name() : "UNDEFINED" ) );
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/java/main/gov/nist/ucef/hla/example/smart/helpers/_SmartPingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/helpers/_SmartPingFederate.java
@@ -62,6 +62,47 @@ public abstract class _SmartPingFederate extends NoOpFederate
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////////// RTI Callback Methods ///////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void receiveInteraction( HLAInteraction hlaInteraction )
+	{
+		String interactionClassName = hlaInteraction.getInteractionClassName(); 
+		if( Pong.interactionName().equals( interactionClassName ) )
+		{
+			receivePongInteraction( new Pong( hlaInteraction ) );
+		}
+		else
+		{
+			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
+			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
+			                                   interactionClassName ) );
+		}
+	}
+	
+	@Override
+	public void receiveAttributeReflection( HLAObject hlaObject ) 
+	{ 
+		String objectClassName = hlaObject.getObjectClassName(); 
+		if( Player.objectClassName().equals( objectClassName ) )
+		{
+			receivePlayerUpdate( new Player( hlaObject ) );
+		}
+		else
+		{
+			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
+			System.err.println( String.format( "Received an unexpected attribute reflection of type '%s'",
+			                                   objectClassName ) );
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////// Internal Utility Methods /////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public Player register( Player player ) { return (Player)super.register( player ); }
+
 	/**
 	 * Handle receipt of a {@link Pong}
 	 * 
@@ -76,39 +117,6 @@ public abstract class _SmartPingFederate extends NoOpFederate
 	 */
 	protected abstract void receivePlayerUpdate( Player player );
 
-	////////////////////////////////////////////////////////////////////////////////////////////
-	/////////////////////////////////// RTI Callback Methods ///////////////////////////////////
-	////////////////////////////////////////////////////////////////////////////////////////////
-	@Override
-	public void receiveInteraction( HLAInteraction hlaInteraction )
-	{
-		if( rtiamb.isOfKind( hlaInteraction, Pong.interactionName() ) )
-		{
-			receivePongInteraction( new Pong( hlaInteraction ) );
-		}
-		else
-		{
-			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
-			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
-			                                    rtiamb.getInteractionClassName( hlaInteraction ) ) );
-		}
-	}
-	
-	@Override
-	public void receiveAttributeReflection( HLAObject hlaObject ) 
-	{ 
-		if( rtiamb.isOfKind( hlaObject, Player.objectClassName() ) )
-		{
-			receivePlayerUpdate( new Player( hlaObject ) );
-		}
-		else
-		{
-			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
-			System.err.println( String.format( "Received an unexpected attribute reflection of type '%s'",
-			                                   rtiamb.getObjectClassName( hlaObject ) ) );
-		}
-	}
-	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/src/java/main/gov/nist/ucef/hla/example/smart/helpers/_SmartPongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/helpers/_SmartPongFederate.java
@@ -62,14 +62,15 @@ public abstract class _SmartPongFederate extends NoOpFederate
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-	
+
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////////////// RTI Callback Methods ///////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		if( rtiamb.isOfKind( hlaInteraction, Ping.interactionName() ) )
+		String interactionClassName = hlaInteraction.getInteractionClassName();
+		if( Ping.interactionName().equals( interactionClassName ) )
 		{
 			receivePingInteraction( new Ping( hlaInteraction ) );
 		}
@@ -77,14 +78,15 @@ public abstract class _SmartPongFederate extends NoOpFederate
 		{
 			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
 			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
-			                                   rtiamb.getInteractionClassName( hlaInteraction ) ) );
+			                                   interactionClassName ) );
 		}
 	}
 
 	@Override
 	public void receiveAttributeReflection( HLAObject hlaObject ) 
 	{ 
-		if( rtiamb.isOfKind( hlaObject, Player.objectClassName() ) )
+		String objectClassName = hlaObject.getObjectClassName();
+		if( Player.objectClassName().equals( objectClassName ) )
 		{
 			receivePlayerUpdate( new Player( hlaObject ) );
 		}
@@ -92,13 +94,15 @@ public abstract class _SmartPongFederate extends NoOpFederate
 		{
 			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
 			System.err.println( String.format( "Received an unexpected attribute reflection of type '%s'",
-			                                   rtiamb.getObjectClassName( hlaObject ) ) );
+			                                   objectClassName ) );
 		}
 	}
 
 	////////////////////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////// Internal Utility Methods /////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
+	protected Player register( Player player ) { return (Player)super.register( player ); }
+
 	/**
 	 * Handle receipt of a {@link Ping}
 	 * 

--- a/src/java/main/gov/nist/ucef/hla/example/smart/interactions/Ping.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/interactions/Ping.java
@@ -47,13 +47,10 @@ public class Ping extends HLAInteraction
 	//----------------------------------------------------------
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
-	 * @param count the count
 	 */
-	public Ping( RTIAmbassadorWrapper rtiamb, int count)
+	public Ping()
 	{
-		super( rtiamb.getInteractionClassHandle( INTERACTION_NAME ), null );
-
-		count( count );
+		super( INTERACTION_NAME, null );
 	}
 
 	/**
@@ -77,9 +74,11 @@ public class Ping extends HLAInteraction
 		return isPresent( PARAM_KEY_COUNT );
 	}
 	
-	public void count( int count )
+	public Ping count( int count )
 	{
 		setValue( PARAM_KEY_COUNT, count );
+		// return instance for chaining
+		return this;
 	}
 
 	public int count()

--- a/src/java/main/gov/nist/ucef/hla/example/smart/interactions/Pong.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/interactions/Pong.java
@@ -47,13 +47,10 @@ public class Pong extends HLAInteraction
 	//----------------------------------------------------------
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
-	 * @param letter the letter
 	 */
-	public Pong( RTIAmbassadorWrapper rtiamb, char letter )
+	public Pong()
 	{
-		super( rtiamb.getInteractionClassHandle( INTERACTION_NAME ), null );
-
-		letter( letter );
+		super( INTERACTION_NAME, null );
 	}
 
 	/**
@@ -77,9 +74,11 @@ public class Pong extends HLAInteraction
 		return isPresent( PARAM_KEY_LETTER );
 	}
 	
-	public void letter( char letter )
+	public Pong letter( char letter )
 	{
 		setValue( PARAM_KEY_LETTER, letter );
+		// return instance for chaining
+		return this;
 	}
 
 	public char letter()

--- a/src/java/main/gov/nist/ucef/hla/example/smart/reflections/Player.java
+++ b/src/java/main/gov/nist/ucef/hla/example/smart/reflections/Player.java
@@ -49,13 +49,10 @@ public class Player extends HLAObject
 	//----------------------------------------------------------
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
-	 * @param name the {@link Player} name
 	 */
-	public Player( RTIAmbassadorWrapper rtiamb, String name )
+	public Player()
 	{
-		super( rtiamb.registerObjectInstance( OBJECT_CLASS_NAME ), null );
-		
-		name( name );
+		super( OBJECT_CLASS_NAME, null, null );
 	}
 
 	/**
@@ -74,14 +71,16 @@ public class Player extends HLAObject
 	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 
-	public void isNamePresent()
+	public boolean isNamePresent()
 	{
-		isPresent( ATTRIBUTE_KEY_NAME );
+		return isPresent( ATTRIBUTE_KEY_NAME );
 	}
 	
-	public void name( String name )
+	public Player name( String name )
 	{
 		setValue( ATTRIBUTE_KEY_NAME, name );
+		// return instance for chaining
+		return this;
 	}
 
 	public String name()

--- a/src/java/main/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
@@ -142,7 +142,8 @@ public class UCEFPingFederate extends UCEFFederateBase
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		if( rtiamb.isOfKind( hlaInteraction, PONG_INTERACTION_NAME ) )
+		String interactionClassName = hlaInteraction.getInteractionClassName();
+		if( PONG_INTERACTION_NAME.equals( interactionClassName ) )
 		{
 			// Pong interaction received
 			if( hlaInteraction.isPresent( PONG_PARAM_LETTER ) )
@@ -160,7 +161,7 @@ public class UCEFPingFederate extends UCEFFederateBase
 		{
 			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
 			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
-			                                    rtiamb.getInteractionClassName( hlaInteraction ) ) );
+			                                   interactionClassName ) );
 		}
 	}
 
@@ -272,7 +273,7 @@ public class UCEFPingFederate extends UCEFFederateBase
 	private static FederateConfiguration makeConfig()
 	{
 		FederateConfiguration config = new FederateConfiguration( "Ping",                 // name
-		                                                          "PingPongFederate",     // type
+		                                                          "PingFederate",     // type
 		                                                          "PingPongFederation" ); // execution
 
 		// set up lists of interactions to be published and subscribed to

--- a/src/java/main/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
@@ -142,7 +142,8 @@ public class UCEFPongFederate extends UCEFFederateBase
 	@Override
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
-		if( rtiamb.isOfKind( hlaInteraction, PING_INTERACTION_NAME ) )
+		String interactionClassName = hlaInteraction.getInteractionClassName();
+		if( PING_INTERACTION_NAME.equals( interactionClassName ) )
 		{
 			// Ping interaction received
 			if( hlaInteraction.isPresent( PING_PARAM_COUNT ) )
@@ -160,7 +161,7 @@ public class UCEFPongFederate extends UCEFFederateBase
 		{
 			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
 			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
-			                                   rtiamb.getInteractionClassName( hlaInteraction ) ) );
+			                                   interactionClassName) );
 		}
 	}
 
@@ -272,7 +273,7 @@ public class UCEFPongFederate extends UCEFFederateBase
 	private static FederateConfiguration makeConfig()
 	{
 		FederateConfiguration config = new FederateConfiguration( "Pong",                 // name
-		                                                          "PingPongFederate",     // type
+		                                                          "PongFederate",     // type
 		                                                          "PingPongFederation" ); // execution
 
 		// set up lists of interactions to be published and subscribed to

--- a/src/java/main/gov/nist/ucef/hla/ucef/FederateJoin.java
+++ b/src/java/main/gov/nist/ucef/hla/ucef/FederateJoin.java
@@ -49,9 +49,9 @@ public class FederateJoin extends HLAInteraction
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
 	 */
-	public FederateJoin( RTIAmbassadorWrapper rtiamb )
+	public FederateJoin()
 	{
-		super( rtiamb.getInteractionClassHandle( INTERACTION_NAME ) );
+		super( INTERACTION_NAME );
 	}
 
 	/**

--- a/src/java/main/gov/nist/ucef/hla/ucef/SimEnd.java
+++ b/src/java/main/gov/nist/ucef/hla/ucef/SimEnd.java
@@ -47,9 +47,9 @@ public class SimEnd extends HLAInteraction
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
 	 */
-	public SimEnd( RTIAmbassadorWrapper rtiamb )
+	public SimEnd()
 	{
-		super( rtiamb.getInteractionClassHandle( INTERACTION_NAME ) );
+		super( INTERACTION_NAME );
 	}
 
 	/**

--- a/src/java/main/gov/nist/ucef/hla/ucef/SimPause.java
+++ b/src/java/main/gov/nist/ucef/hla/ucef/SimPause.java
@@ -47,9 +47,9 @@ public class SimPause extends HLAInteraction
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
 	 */
-	public SimPause( RTIAmbassadorWrapper rtiamb )
+	public SimPause()
 	{
-		super( rtiamb.getInteractionClassHandle( INTERACTION_NAME ) );
+		super( INTERACTION_NAME );
 	}
 	
 	/**

--- a/src/java/main/gov/nist/ucef/hla/ucef/SimResume.java
+++ b/src/java/main/gov/nist/ucef/hla/ucef/SimResume.java
@@ -47,9 +47,9 @@ public class SimResume extends HLAInteraction
 	/**
 	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
 	 */
-	public SimResume( RTIAmbassadorWrapper rtiamb )
+	public SimResume()
 	{
-		super( rtiamb.getInteractionClassHandle( INTERACTION_NAME ) );
+		super( INTERACTION_NAME );
 	}
 	
 	/**

--- a/src/java/main/gov/nist/ucef/hla/ucef/UCEFFederateBase.java
+++ b/src/java/main/gov/nist/ucef/hla/ucef/UCEFFederateBase.java
@@ -23,8 +23,11 @@
  */
 package gov.nist.ucef.hla.ucef;
 
+import java.util.Map;
+
 import gov.nist.ucef.hla.base.FederateBase;
 import gov.nist.ucef.hla.base.HLAInteraction;
+import hla.rti1516e.InteractionClassHandle;
 
 /**
  * An abstract implementation for a UCEF Federate which is aware of certain
@@ -186,62 +189,84 @@ public abstract class UCEFFederateBase extends FederateBase
 	 * Override to provide handling for specific UCEF simulation control interaction types
 	 */
 	@Override
-	public void incomingInteraction( HLAInteraction interaction, double time )
+	public void incomingInteraction( InteractionClassHandle handle, Map<String,byte[]> parameters, double time )
 	{
 		// delegate to handlers for UCEF Simulation control interactions as required
-		if( rtiamb.isOfKind( interaction, SimEnd.interactionName() ) )
+		HLAInteraction interaction = makeInteraction( handle, parameters );
+		
+		if( interaction != null )
 		{
-			simShouldEnd = true;
-			receiveSimEnd( new SimEnd( interaction ), time );
-		}
-		else if( rtiamb.isOfKind( interaction, SimPause.interactionName() ) )
-		{
-			simShouldPause = true;
-			receiveSimPause( new SimPause( interaction ), time );
-		}
-		else if( rtiamb.isOfKind( interaction, SimResume.interactionName() ) )
-		{
-			simShouldPause = false;
-			receiveSimResume( new SimResume( interaction ), time );
-		}
-		else if( rtiamb.isOfKind( interaction, FederateJoin.interactionName() ) )
-		{
-			receiveFederateJoin( new FederateJoin( interaction ), time );
+    		String interactionClassName = interaction.getInteractionClassName();
+    		
+    		if( SimEnd.interactionName().equals( interactionClassName ) )
+    		{
+    			simShouldEnd = true;
+    			receiveSimEnd( new SimEnd( interaction ), time );
+    		}
+    		else if( SimPause.interactionName().equals( interactionClassName ) )
+    		{
+    			simShouldPause = true;
+    			receiveSimPause( new SimPause( interaction ), time );
+    		}
+    		else if( SimResume.interactionName().equals( interactionClassName ) )
+    		{
+    			simShouldPause = false;
+    			receiveSimResume( new SimResume( interaction ), time );
+    		}
+    		else if( FederateJoin.interactionName().equals( interactionClassName ) )
+    		{
+    			receiveFederateJoin( new FederateJoin( interaction ), time );
+    		}
+    		else
+    		{
+    			// anything else gets generic interaction receipt handling
+    			receiveInteraction( interaction, time );
+    		}
 		}
 		else
 		{
-			// anything else gets generic interaction receipt handling
-			receiveInteraction( interaction, time );
+			// TODO Log error
 		}
 	}
 	
 	@Override
-	public void incomingInteraction( HLAInteraction interaction )
+	public void incomingInteraction( InteractionClassHandle handle, Map<String,byte[]> parameters )
 	{
 		// delegate to handlers for UCEF Simulation control interactions as required
-		if( rtiamb.isOfKind( interaction, SimEnd.interactionName() ) )
+		HLAInteraction interaction = makeInteraction( handle, parameters );
+		
+		if( interaction != null )
 		{
-			simShouldEnd = true;
-			receiveSimEnd( new SimEnd( interaction ) );
-		}
-		else if( rtiamb.isOfKind( interaction, SimPause.interactionName() ) )
-		{
-			simShouldPause = true;
-			receiveSimPause( new SimPause( interaction ) );
-		}
-		else if( rtiamb.isOfKind( interaction, SimResume.interactionName() ) )
-		{
-			simShouldPause = false;
-			receiveSimResume( new SimResume( interaction ) );
-		}
-		else if( rtiamb.isOfKind( interaction, FederateJoin.interactionName() ) )
-		{
-			receiveFederateJoin( new FederateJoin( interaction ) );
+    		String interactionClassName = interaction.getInteractionClassName();
+    		
+    		if( SimEnd.interactionName().equals( interactionClassName ) )
+    		{
+    			simShouldEnd = true;
+    			receiveSimEnd( new SimEnd( interaction ) );
+    		}
+    		else if( SimPause.interactionName().equals( interactionClassName ) )
+    		{
+    			simShouldPause = true;
+    			receiveSimPause( new SimPause( interaction ) );
+    		}
+    		else if( SimResume.interactionName().equals( interactionClassName ) )
+    		{
+    			simShouldPause = false;
+    			receiveSimResume( new SimResume( interaction ) );
+    		}
+    		else if( FederateJoin.interactionName().equals( interactionClassName ) )
+    		{
+    			receiveFederateJoin( new FederateJoin( interaction ) );
+    		}
+    		else
+    		{
+    			// anything else gets generic interaction receipt handling
+    			receiveInteraction( interaction );
+    		}
 		}
 		else
 		{
-			// anything else gets generic interaction receipt handling
-			receiveInteraction( interaction );
+			// TODO Log error
 		}
 	}
 	


### PR DESCRIPTION
Significant refactoring of code so that an RTIAmbassador instance is no longer required as an argument to create "smart" HLAObject instances.

The changes also mean that the C++ and Java source are more closely matched from a code similarity perspective.