### PR TITLE
Federate Departure Detection for Federation Manager Federates

### DIFF
--- a/src/java/main/gov/nist/ucef/hla/base/RTIAmbassadorWrapper.java
+++ b/src/java/main/gov/nist/ucef/hla/base/RTIAmbassadorWrapper.java
@@ -561,28 +561,6 @@ public class RTIAmbassadorWrapper
 	}
 	
 	/**
-	 * Determine if an {@link HLAObject} instance has the {@link ObjectClassHandle} corresponding
-	 * to the given object class name
-	 * 
-	 * @param interaction the {@link HLAInteraction} instance to check
-	 * @param objectClassName the name of the object class to check
-	 * @return true if the {@link HLAObject} instance has an {@link ObjectClassHandle}
-	 *         corresponding to the given object class name, false otherwise
-	 */
-	public boolean isOfKind( HLAObject object, String objectClassName )
-	{
-		try
-		{
-			return isOfKind( object, getObjectClassHandle( objectClassName ) );
-		}
-		catch( UCEFException e )
-		{
-			// ignore - this will occur if the object class name is unknown
-		}
-		return false;
-	}
-	
-	/**
 	 * Determine if an {@link HLAObject} instance has the given
 	 * {@link ObjectClassHandle}
 	 * 


### PR DESCRIPTION
Federation manager federates now detect when federates leave via the `receiveObjectDeleted()` callback, updating the start conditions appropriately.

An ungracefully exiting federate (i.e., a federate that crashes or is forcibly 'killed') will also be detected after a timeout of about 30 seconds. The absence of the federate is detected by the Portico framework itself, which sends resignation details in lieu of the original federate doing so.