### PR TITLE
Some updates related to feedback from Tom

### DIFF
--- a/src/java/main/gov/nist/ucef/hla/base/FederateAmbassador.java
+++ b/src/java/main/gov/nist/ucef/hla/base/FederateAmbassador.java
@@ -205,12 +205,6 @@ public class FederateAmbassador extends NullFederateAmbassador
 		{
 			this.announcedPoints.add( label );
 		}
-		
-		if( UCEFSyncPoint.isUnknown( label ) )
-		{
-			// non-UCEF synchronization point - should probably just achieve it immediately
-			this.federateBase.rtiamb.synchronizationPointAchieved( label );
-		}
 	}
 
 	@Override

--- a/src/java/main/gov/nist/ucef/hla/base/Types.java
+++ b/src/java/main/gov/nist/ucef/hla/base/Types.java
@@ -23,8 +23,18 @@
  */
 package gov.nist.ucef.hla.base;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import hla.rti1516e.encoding.HLAboolean;
+import hla.rti1516e.encoding.HLAfloat32BE;
+import hla.rti1516e.encoding.HLAfloat64BE;
+import hla.rti1516e.encoding.HLAinteger16BE;
+import hla.rti1516e.encoding.HLAinteger32BE;
+import hla.rti1516e.encoding.HLAinteger64BE;
+import hla.rti1516e.encoding.HLAunicodeChar;
+import hla.rti1516e.encoding.HLAunicodeString;
 
 public class Types
 {
@@ -32,6 +42,74 @@ public class Types
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
 
+	//----------------------------------------------------------
+	//                      ENUMERATIONS
+	//----------------------------------------------------------
+	/**
+	 *  Represents data type of an attribute or interaction parameter
+	 *
+	 *  @see ObjectAttribute
+	 *  @see InteractionParameter
+	 */
+	@SuppressWarnings("rawtypes")
+	enum DataType
+	{
+		BYTE(    "bytes",   Byte[].class,    null),
+		CHAR(    "char",    Character.class, HLAunicodeChar.class),
+		SHORT(   "short",   Short.class,     HLAinteger16BE.class),
+		INT(     "int",     Integer.class,   HLAinteger32BE.class),
+		LONG(    "long",    Long.class,      HLAinteger64BE.class),
+		FLOAT(   "float",   Float.class,     HLAfloat32BE.class),
+		DOUBLE(  "double",  Double.class,    HLAfloat64BE.class),
+		BOOLEAN( "boolean", Boolean.class,   HLAboolean.class),
+		STRING(  "string",  String.class,    HLAunicodeString.class),
+		UNKNOWN( "unknown", null,            null);
+		
+		// a map for finding a datat type for a string key - this is to provide
+		// quick lookups and avoid iterating over all data types
+		private static final Map<String,DataType> DATATYPE_LOOKUP =
+		    Collections.unmodifiableMap( initializeMapping() );
+
+		public String label;
+		public Class javaType;
+		public Class hlaType;
+		
+		DataType( String label, Class javaType, Class hlaType )
+		{
+			this.label = label;
+			this.javaType = javaType;
+			this.hlaType = hlaType;
+		}
+		
+		/**
+		 * Converts a text identifier uniquely identifying a data type to a {@link DataType}
+		 * instance.
+		 * 
+		 * NOTE: if the key is not a valid text identifier for a data type, UNKNOWN be returned
+		 * 
+		 * @param label the text identifier uniquely identifying a data type
+		 * @return the corresponding {@link DataType}, or {@link DataType#UNKNOWN} if the key is
+		 *         not a valid text identifier for a {@link DataType}.
+		 */
+		public static DataType fromLabel( String label )
+		{
+			return DATATYPE_LOOKUP.getOrDefault( label.toLowerCase().trim(), UNKNOWN );
+		}
+
+		/**
+		 * Private initializer method for the key-to-{@link DataType} lookup map
+		 * 
+		 * @return a lookup map which pairs text identifiers and the corresponding
+		 *         {@link DataType}s
+		 */
+		private static Map<String,DataType> initializeMapping()
+		{
+			Map<String,DataType> lookupMap = new HashMap<String,DataType>();
+			for( DataType dataType : DataType.values() )
+				lookupMap.put( dataType.label.toLowerCase().trim(), dataType );
+			return lookupMap;
+		}
+	};
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
@@ -44,6 +122,7 @@ public class Types
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
 
+	
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
@@ -61,12 +140,14 @@ public class Types
 		public String name;
 		public boolean publish;
 		public boolean subscribe;
+		public DataType dataType;
 
 		public ObjectAttribute( String name )
 		{
 			this.name = name;
 			this.publish = false;
 			this.subscribe = false;
+			this.dataType = DataType.UNKNOWN;
 		}
 	}
 
@@ -100,10 +181,12 @@ public class Types
 	protected static class InteractionParameter
 	{
 		public String name;
+		public DataType dataType;
 
 		public InteractionParameter( String name )
 		{
 			this.name = name;
+			this.dataType = DataType.UNKNOWN;
 		}
 	}
 

--- a/src/java/main/gov/nist/ucef/hla/example/fedman/FedManFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/fedman/FedManFederate.java
@@ -449,7 +449,8 @@ public class FedManFederate extends NoOpFederate
 	{
 		for( UCEFSyncPoint syncPoint : UCEFSyncPoint.values() )
 		{
-			registerSyncPointAndWaitForAnnounce( syncPoint.getLabel(), null );
+			registerSyncPoint( syncPoint.getLabel(), null );
+			waitForSyncPointAnnouncement( syncPoint.getLabel() );
 		}
 	}
 	

--- a/src/java/main/gov/nist/ucef/hla/example/immediate/federates/ImmediatePingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/immediate/federates/ImmediatePingFederate.java
@@ -1,0 +1,235 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.example.immediate.federates;
+
+import gov.nist.ucef.hla.base.FederateConfiguration;
+import gov.nist.ucef.hla.base.UCEFException;
+import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.example.immediate.helpers._ImmediatePingFederate;
+import gov.nist.ucef.hla.example.smart.interactions.Ping;
+import gov.nist.ucef.hla.example.smart.interactions.Pong;
+import gov.nist.ucef.hla.example.smart.reflections.Player;
+import gov.nist.ucef.hla.example.util.Constants;
+import gov.nist.ucef.hla.example.util.FileUtils;
+import gov.nist.ucef.hla.ucef.SimEnd;
+import gov.nist.ucef.hla.ucef.SimPause;
+import gov.nist.ucef.hla.ucef.SimResume;
+
+/**
+ *		            ___
+ *		          _/   \_     _     _
+ *		         / \   / \   / \   / \
+ *		        ( U )─( C )─( E )─( F )
+ *		         \_/   \_/   \_/   \_/
+ *		        <─┴─> <─┴─────┴─────┴─>
+ *		       Universal CPS Environment
+ *		             for Federation
+ * 
+ * Example federate for testing
+ */
+public class ImmediatePingFederate extends _ImmediatePingFederate
+{
+	//----------------------------------------------------------
+	//                   STATIC VARIABLES
+	//----------------------------------------------------------
+	private static String[] PLAYER_NAMES= {"Alice Ping", "Bob Ping", "Carol Ping", "David Ping"};
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private int count;
+	private Player player;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public ImmediatePingFederate( String[] args )
+	{
+		super();
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	////////////////////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////// Lifecycle Callback Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void beforeReadyToPopulate()
+	{
+		System.out.println( String.format( "Waiting for '%s' synchronization point...",
+		                                   UCEFSyncPoint.READY_TO_POPULATE ) );
+	}
+
+	@Override
+	public void beforeFirstStep()
+	{
+		this.count =  0;
+		this.player = register( new Player() );
+	}
+
+	@Override
+	public boolean step( double currentTime )
+	{
+		// here we end out our interaction and attribute update
+		sendInteraction( new Ping().count(  this.count ) );
+		// update the values
+		this.count++;
+		String nextPlayerName = PLAYER_NAMES[this.count % PLAYER_NAMES.length];
+		this.player.name( nextPlayerName );
+		// keep going until time 10.0
+		return (currentTime < 10.0);
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////// Interaction/Reflection Handler Callbacks ////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Handle receipt of a {@link Pong}
+	 * 
+	 * @param pong the interaction to handle
+	 */
+	@Override
+	protected void receivePongInteraction( Pong pong )
+	{
+		System.out.println( String.format( "Received Pong interaction - letter is '%s'.",
+		                                   pong.isLetterPresent() ? pong.letter() : "UNDEFINED" ) );
+		updateAttributeValues( this.player );
+	}
+
+	/**
+	 * Handle receipt of a {@link Player}
+	 * 
+	 * @param player the object to handle
+	 */
+	@Override
+	protected void receivePlayerUpdate( Player player )
+	{
+		System.out.println( String.format( "Received Player update - name is %s",
+		                                   player.isNamePresent() ? player.name() : "UNDEFINED" ) );
+		sendInteraction( new Ping().count(  this.count ) );
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////// UCEF Simulation Control Interaction Callbacks ///////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	protected void receiveSimPause( SimPause simPause )
+	{
+		System.out.println( "Simulation has been paused." );
+	}
+
+	@Override
+	protected void receiveSimResume( SimResume simResume )
+	{
+		System.out.println( "Simulation has been resumed." );
+	}
+	
+	@Override
+	protected void receiveSimEnd( SimEnd simEnd )
+	{
+		System.out.println( "SimEnd signal received. Simulation will be terminated..." );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/**
+	 * Utility function to set up some useful configuration
+	 * 
+	 * @return a usefully populated {@link FederateConfiguration} instance
+	 */
+	private static FederateConfiguration makeConfig()
+	{
+		FederateConfiguration config = new FederateConfiguration( "Ping",                 // name
+		                                                          "PingFederate",         // type
+		                                                          "PingPongFederation" ); // execution
+
+		// set up lists of objects/attributes to be published and subscribed to
+		config.addPublishedAttributes( Player.objectClassName(), Player.attributeNames() );
+		config.addSubscribedAttributes( Player.objectClassName(), Player.attributeNames() );
+		// set up lists of interactions to be published and subscribed to
+		config.addPublishedInteraction( Ping.interactionClassName() );
+		config.addSubscribedInteraction( Pong.interactionClassName() );
+		// subscribed UCEF simulation control interactions
+		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
+		                                  SimEnd.interactionName() );
+
+		// somebody set us up the FOM...
+		try
+		{
+			String fomRootPath = "resources/foms/";
+			// modules
+			String[] moduleFoms = { fomRootPath + "SmartPingPong.xml" };
+			config.addModules( FileUtils.urlsFromPaths( moduleFoms ) );
+
+			// join modules
+			String[] joinModuleFoms = {};
+			config.addJoinModules( FileUtils.urlsFromPaths( joinModuleFoms ) );
+		}
+		catch( Exception e )
+		{
+			throw new UCEFException( "Exception loading one of the FOM modules from disk", e );
+		}
+
+		return config;
+	}
+
+	/**
+	 * Main method
+	 * 
+	 * @param args ignored
+	 */
+	public static void main( String[] args )
+	{
+		System.out.println( Constants.UCEF_LOGO );
+		System.out.println();
+		System.out.println( "	       .__                " );
+		System.out.println( "	______ |__| ____    ____" );
+		System.out.println( "	\\____ \\|  |/    \\  / ___\\" );
+		System.out.println( "	|  |_> >  |   |  \\/ /_/  >" );
+		System.out.println( "	|   __/|__|___|  /\\___  /" );
+		System.out.println( "	|__|           \\//_____/" );
+		System.out.println( "	   Smart Ping Federate" );
+		System.out.println();
+		System.out.println( "Sends 'Ping' interactions.");
+		System.out.println( "Receives 'Pong' interactions.");
+		System.out.println();
+
+		try
+		{
+			new ImmediatePingFederate( args ).runFederate( makeConfig() );
+		}
+		catch( Exception e )
+		{
+			e.printStackTrace();
+			System.err.println( e.getMessage() );
+			System.err.println( "Cannot proceed - shutting down now." );
+			System.exit( 1 );
+		}
+
+		System.out.println( "Completed - shutting down now." );
+		System.exit( 0 );
+	}
+}

--- a/src/java/main/gov/nist/ucef/hla/example/immediate/federates/ImmediatePongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/immediate/federates/ImmediatePongFederate.java
@@ -1,0 +1,233 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.example.immediate.federates;
+
+import gov.nist.ucef.hla.base.FederateConfiguration;
+import gov.nist.ucef.hla.base.UCEFException;
+import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.example.immediate.helpers._ImmediatePongFederate;
+import gov.nist.ucef.hla.example.smart.interactions.Ping;
+import gov.nist.ucef.hla.example.smart.interactions.Pong;
+import gov.nist.ucef.hla.example.smart.reflections.Player;
+import gov.nist.ucef.hla.example.util.Constants;
+import gov.nist.ucef.hla.example.util.FileUtils;
+import gov.nist.ucef.hla.ucef.SimEnd;
+import gov.nist.ucef.hla.ucef.SimPause;
+import gov.nist.ucef.hla.ucef.SimResume;
+
+/**
+ *		            ___
+ *		          _/   \_     _     _
+ *		         / \   / \   / \   / \
+ *		        ( U )─( C )─( E )─( F )
+ *		         \_/   \_/   \_/   \_/
+ *		        <─┴─> <─┴─────┴─────┴─>
+ *		       Universal CPS Environment
+ *		             for Federation
+ * 
+ * Example federate for testing
+ */
+public class ImmediatePongFederate extends _ImmediatePongFederate
+{
+	//----------------------------------------------------------
+	//                   STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private char letter;
+	private Player player;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public ImmediatePongFederate( String[] args )
+	{
+		super();
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	////////////////////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////// Lifecycle Callback Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void beforeReadyToPopulate()
+	{
+		System.out.println( String.format( "Waiting for '%s' synchronization point...",
+		                                   UCEFSyncPoint.READY_TO_POPULATE ) );
+	}
+
+	@Override
+	public void beforeFirstStep()
+	{
+		this.letter = 'a';
+		this.player = register( new Player() );
+	}
+
+	@Override
+	public boolean step( double currentTime )
+	{
+		// here we end out our interaction and attribute update
+		sendInteraction( new Pong().letter( this.letter ) );
+		// update the values
+		this.letter++;
+		String nextPlayerName = (this.player.isNamePresent() ? this.player.name() : "") + this.letter;
+		this.player.name( nextPlayerName );
+		// keep going until time 10.0
+		return (currentTime < 10.0);
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////// Interaction/Reflection Handler Callbacks ////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Handle receipt of a {@link Ping}
+	 * 
+	 * @param ping the interaction to handle
+	 */
+	@Override
+	protected void receivePingInteraction( Ping ping )
+	{
+		System.out.println( String.format( "Received Ping interaction - count is %s",
+		                                   ping.isCountPresent() ? ping.count() : "UNDEFINED" ) );
+		updateAttributeValues( this.player );
+	}
+
+	/**
+	 * Handle receipt of a {@link Player}
+	 * 
+	 * @param player the object to handle
+	 */
+	@Override
+	protected void receivePlayerUpdate( Player player )
+	{
+		System.out.println( String.format( "Received Player update - name is %s",
+		                                   player.isNamePresent() ? player.name() : "UNDEFINED" ) );
+		sendInteraction( new Pong().letter( this.letter ) );
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////// UCEF Simulation Control Interaction Callbacks ///////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	protected void receiveSimPause( SimPause simPause )
+	{
+		System.out.println( "Simulation has been paused." );
+	}
+
+	@Override
+	protected void receiveSimResume( SimResume simResume )
+	{
+		System.out.println( "Simulation has been resumed." );
+	}
+	
+	@Override
+	protected void receiveSimEnd( SimEnd simEnd )
+	{
+		System.out.println( "SimEnd signal received. Simulation will be terminated..." );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/**
+	 * Utility function to set up some useful configuration
+	 * 
+	 * @return a usefully populated {@link FederateConfiguration} instance
+	 */
+	private static FederateConfiguration makeConfig()
+	{
+		FederateConfiguration config = new FederateConfiguration( "Pong",                 // name
+		                                                          "PongFederate",         // type
+		                                                          "PingPongFederation" ); // execution
+
+		// set up lists of objects/attributes to be published and subscribed to
+		config.addPublishedAttributes( Player.objectClassName(), Player.attributeNames() );
+		config.addSubscribedAttributes( Player.objectClassName(), Player.attributeNames() );
+		// set up lists of interactions to be published and subscribed to
+		config.addPublishedInteraction( Pong.interactionClassName() );
+		config.addSubscribedInteraction( Ping.interactionClassName() );
+		// subscribed UCEF simulation control interactions
+		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
+		                                  SimEnd.interactionName() );
+
+		// somebody set us up the FOM...
+		try
+		{
+			String fomRootPath = "resources/foms/";
+			// modules
+			String[] moduleFoms = { fomRootPath + "SmartPingPong.xml" };
+			config.addModules( FileUtils.urlsFromPaths( moduleFoms ) );
+
+			// join modules
+			String[] joinModuleFoms = {};
+			config.addJoinModules( FileUtils.urlsFromPaths( joinModuleFoms ) );
+		}
+		catch( Exception e )
+		{
+			throw new UCEFException( "Exception loading one of the FOM modules from disk", e );
+		}
+
+		return config;
+	}
+
+	/**
+	 * Main method
+	 * 
+	 * @param args ignored
+	 */
+	public static void main( String[] args )
+	{
+		System.out.println( Constants.UCEF_LOGO );
+		System.out.println();
+		System.out.println( "	______   ____   ____    ____  " );
+		System.out.println( "	\\____ \\ /  _ \\ /    \\  / ___\\" );
+		System.out.println( "	|  |_> >  <_> )   |  \\/ /_/  >" );
+		System.out.println( "	|   __/ \\____/|___|  /\\___  /" );
+		System.out.println( "	|__|               \\//_____/" );
+		System.out.println( "	     Smart Pong Federate" );
+		System.out.println();
+		System.out.println( "Sends 'Pong' interactions.");
+		System.out.println( "Receives 'Ping' interactions.");
+		System.out.println();
+
+		try
+		{
+			new ImmediatePongFederate( args ).runFederate( makeConfig() );
+		}
+		catch( Exception e )
+		{
+			e.printStackTrace();
+			System.err.println( e.getMessage() );
+			System.err.println( "Cannot proceed - shutting down now." );
+			System.exit( 1 );
+		}
+
+		System.out.println( "Completed - shutting down now." );
+		System.exit( 0 );
+	}
+}

--- a/src/java/main/gov/nist/ucef/hla/example/immediate/helpers/_ImmediatePingFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/immediate/helpers/_ImmediatePingFederate.java
@@ -1,0 +1,123 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.example.immediate.helpers;
+
+import gov.nist.ucef.hla.base.HLAInteraction;
+import gov.nist.ucef.hla.base.HLAObject;
+import gov.nist.ucef.hla.example.smart.interactions.Pong;
+import gov.nist.ucef.hla.example.smart.reflections.Player;
+import gov.nist.ucef.hla.ucef.NoOpFederate;
+
+/**
+ *		            ___
+ *		          _/   \_     _     _
+ *		         / \   / \   / \   / \
+ *		        ( U )─( C )─( E )─( F )
+ *		         \_/   \_/   \_/   \_/
+ *		        <─┴─> <─┴─────┴─────┴─>
+ *		       Universal CPS Environment
+ *		             for Federation
+ * 
+ * Example federate for testing
+ */
+public abstract class _ImmediatePingFederate extends NoOpFederate
+{
+	//----------------------------------------------------------
+	//                   STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public _ImmediatePingFederate()
+	{
+		super();
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////////// RTI Callback Methods ///////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void receiveInteraction( HLAInteraction hlaInteraction )
+	{
+		String interactionClassName = hlaInteraction.getInteractionClassName(); 
+		if( Pong.interactionClassName().equals( interactionClassName ) )
+		{
+			receivePongInteraction( new Pong( hlaInteraction ) );
+		}
+		else
+		{
+			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
+			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
+			                                   interactionClassName ) );
+		}
+	}
+	
+	@Override
+	public void receiveAttributeReflection( HLAObject hlaObject ) 
+	{ 
+		String objectClassName = hlaObject.getObjectClassName(); 
+		if( Player.objectClassName().equals( objectClassName ) )
+		{
+			receivePlayerUpdate( new Player( hlaObject ) );
+		}
+		else
+		{
+			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
+			System.err.println( String.format( "Received an unexpected attribute reflection of type '%s'",
+			                                   objectClassName ) );
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////// Internal Utility Methods /////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public Player register( Player player ) { return (Player)super.register( player ); }
+
+	/**
+	 * Handle receipt of a {@link Pong}
+	 * 
+	 * @param pong the interaction to handle
+	 */
+	protected abstract void receivePongInteraction( Pong pong );
+
+	/**
+	 * Handle receipt of a {@link Player}
+	 * 
+	 * @param player the object to handle
+	 */
+	protected abstract void receivePlayerUpdate( Player player );
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/src/java/main/gov/nist/ucef/hla/example/immediate/helpers/_ImmediatePongFederate.java
+++ b/src/java/main/gov/nist/ucef/hla/example/immediate/helpers/_ImmediatePongFederate.java
@@ -1,0 +1,123 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.example.immediate.helpers;
+
+import gov.nist.ucef.hla.base.HLAInteraction;
+import gov.nist.ucef.hla.base.HLAObject;
+import gov.nist.ucef.hla.example.smart.interactions.Ping;
+import gov.nist.ucef.hla.example.smart.reflections.Player;
+import gov.nist.ucef.hla.ucef.NoOpFederate;
+
+/**
+ *		            ___
+ *		          _/   \_     _     _
+ *		         / \   / \   / \   / \
+ *		        ( U )─( C )─( E )─( F )
+ *		         \_/   \_/   \_/   \_/
+ *		        <─┴─> <─┴─────┴─────┴─>
+ *		       Universal CPS Environment
+ *		             for Federation
+ * 
+ * Example federate for testing
+ */
+public abstract class _ImmediatePongFederate extends NoOpFederate
+{
+	//----------------------------------------------------------
+	//                   STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public _ImmediatePongFederate()
+	{
+		super();
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////////// RTI Callback Methods ///////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void receiveInteraction( HLAInteraction hlaInteraction )
+	{
+		String interactionClassName = hlaInteraction.getInteractionClassName();
+		if( Ping.interactionClassName().equals( interactionClassName ) )
+		{
+			receivePingInteraction( new Ping( hlaInteraction ) );
+		}
+		else
+		{
+			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
+			System.err.println( String.format( "Received an unexpected interaction of type '%s'",
+			                                   interactionClassName ) );
+		}
+	}
+
+	@Override
+	public void receiveAttributeReflection( HLAObject hlaObject ) 
+	{ 
+		String objectClassName = hlaObject.getObjectClassName();
+		if( Player.objectClassName().equals( objectClassName ) )
+		{
+			receivePlayerUpdate( new Player( hlaObject ) );
+		}
+		else
+		{
+			// this is unexpected - we shouldn't receive any thing we didn't subscribe to
+			System.err.println( String.format( "Received an unexpected attribute reflection of type '%s'",
+			                                   objectClassName ) );
+		}
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////// Internal Utility Methods /////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	protected Player register( Player player ) { return (Player)super.register( player ); }
+
+	/**
+	 * Handle receipt of a {@link Ping}
+	 * 
+	 * @param ping the interaction to handle
+	 */
+	protected abstract void receivePingInteraction( Ping ping );
+
+	/**
+	 * Handle receipt of a {@link Player}
+	 * 
+	 * @param player the object to handle
+	 */
+	protected abstract void receivePlayerUpdate( Player player );
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/src/java/main/gov/nist/ucef/hla/example/immediate/interactions/Ping.java
+++ b/src/java/main/gov/nist/ucef/hla/example/immediate/interactions/Ping.java
@@ -1,0 +1,101 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.example.immediate.interactions;
+
+import gov.nist.ucef.hla.base.HLAInteraction;
+import gov.nist.ucef.hla.base.RTIAmbassadorWrapper;
+
+public class Ping extends HLAInteraction
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	// HLA identifier of this type of interaction - must match FOM definition
+	private static final String HLA_INTERACTION_ROOT = "HLAInteractionRoot.";
+	private static final String INTERACTION_NAME = HLA_INTERACTION_ROOT+"Ping";
+	
+	// interaction parameters and types
+	private static final String PARAM_KEY_COUNT = "count";
+	
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	/**
+	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
+	 */
+	public Ping()
+	{
+		super( INTERACTION_NAME, null );
+	}
+
+	/**
+	 * @param interaction the {@link HLAInteraction} instance
+	 */
+	public Ping( HLAInteraction interaction )
+	{
+		super( interaction );
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+	public boolean isCountPresent()
+	{
+		return isPresent( PARAM_KEY_COUNT );
+	}
+	
+	public Ping count( int count )
+	{
+		setValue( PARAM_KEY_COUNT, count );
+		// return instance for chaining
+		return this;
+	}
+
+	public int count()
+	{
+		return getAsInt( PARAM_KEY_COUNT );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/**
+	 * Obtain the HLA interaction name identifying this type of interaction
+	 * 
+	 * @return the HLA interaction name identifying this interaction
+	 */
+	public static String interactionClassName()
+	{
+		return INTERACTION_NAME;
+	}
+}

--- a/src/java/main/gov/nist/ucef/hla/example/immediate/interactions/Pong.java
+++ b/src/java/main/gov/nist/ucef/hla/example/immediate/interactions/Pong.java
@@ -1,0 +1,101 @@
+/*
+ * This software is contributed as a public service by The National Institute of Standards 
+ * and Technology (NIST) and is not subject to U.S. Copyright
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+ * software and associated documentation files (the "Software"), to deal in the Software 
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above NIST contribution notice and this permission and disclaimer notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. THE AUTHORS OR COPYRIGHT HOLDERS SHALL
+ * NOT HAVE ANY OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ */
+package gov.nist.ucef.hla.example.immediate.interactions;
+
+import gov.nist.ucef.hla.base.HLAInteraction;
+import gov.nist.ucef.hla.base.RTIAmbassadorWrapper;
+
+public class Pong extends HLAInteraction
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	// HLA identifier of this type of interaction - must match FOM definition
+	private static final String HLA_INTERACTION_ROOT = "HLAInteractionRoot.";
+	private static final String INTERACTION_NAME = HLA_INTERACTION_ROOT+"Pong";
+	
+	// interaction parameters and types
+	private static final String PARAM_KEY_LETTER = "letter";
+	
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	/**
+	 * @param rtiamb the {@link RTIAmbassadorWrapper} instance
+	 */
+	public Pong()
+	{
+		super( INTERACTION_NAME, null );
+	}
+
+	/**
+	 * @param interaction the {@link HLAInteraction} instance
+	 */
+	public Pong( HLAInteraction interaction )
+	{
+		super( interaction );
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+	public boolean isLetterPresent()
+	{
+		return isPresent( PARAM_KEY_LETTER );
+	}
+	
+	public Pong letter( char letter )
+	{
+		setValue( PARAM_KEY_LETTER, letter );
+		// return instance for chaining
+		return this;
+	}
+
+	public char letter()
+	{
+		return getAsChar( PARAM_KEY_LETTER );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/**
+	 * Obtain the HLA interaction name identifying this type of interaction
+	 * 
+	 * @return the HLA interaction name identifying this interaction
+	 */
+	public static String interactionClassName()
+	{
+		return INTERACTION_NAME;
+	}
+}

--- a/src/java/main/gov/nist/ucef/hla/ucef/UCEFFederateBase.java
+++ b/src/java/main/gov/nist/ucef/hla/ucef/UCEFFederateBase.java
@@ -204,6 +204,10 @@ public abstract class UCEFFederateBase extends FederateBase
         		
         		if( SimEnd.interactionName().equals( interactionClassName ) )
         		{
+        			// if a SimEnd is received, a UCEF federate must synchronize with the
+        			// rest of the federation before resigning
+        			this.configuration.setSyncBeforeResign( true );
+        			
         			simShouldEnd = true;
         			receiveSimEnd( new SimEnd( interaction ), time );
         		}
@@ -248,6 +252,10 @@ public abstract class UCEFFederateBase extends FederateBase
         		
         		if( SimEnd.interactionName().equals( interactionClassName ) )
         		{
+        			// if a SimEnd is received, a UCEF federate must synchronize with the
+        			// rest of the federation before resigning
+        			this.configuration.setSyncBeforeResign( true );
+        			
         			simShouldEnd = true;
         			receiveSimEnd( new SimEnd( interaction ) );
         		}

--- a/src/java/test/gov/nist/ucef/hla/base/common/config/FederateConfigurationTest.java
+++ b/src/java/test/gov/nist/ucef/hla/base/common/config/FederateConfigurationTest.java
@@ -85,8 +85,8 @@ public class FederateConfigurationTest extends TestCase
 		assertEquals( federateName, config.getFederateName() );
 		assertEquals( federateType, config.getFederateType() );
 		
-		assertEquals(5, config.getMaxReconnectAttempts());
-		assertEquals(5L, config.getReconnectRetryInterval());
+		assertEquals(5, config.getMaxJoinAttempts());
+		assertEquals(5L, config.getJoinRetryInterval());
 		assertEquals(false, config.isLateJoiner());
 		assertEquals(true, config.isTimeStepped());
 		assertEquals(false, config.callbacksAreEvoked());
@@ -172,8 +172,8 @@ public class FederateConfigurationTest extends TestCase
 			  .addSubscribedAttributes( expectedSubscribedAttributes )
 			  .addPublishedInteractions( expectedPublishedInteractions )
 			  .addSubscribedInteractions( expectedSubscribedInteractions)
-			  .setMaxReconnectAttempts( expectedMaxReconnectAttempts )
-			  .setReconnectRetryInterval( expectedReconnectRetryInterval )
+			  .setMaxJoinAttempts( expectedMaxReconnectAttempts )
+			  .setJoinRetryInterval( expectedReconnectRetryInterval )
 			  .setStepSize( expectedStepSize )
 			  .setLookAhead( expectedLookAhead )
 			  .setLateJoiner( expectedIsLateJoiner )
@@ -187,8 +187,8 @@ public class FederateConfigurationTest extends TestCase
 		assertEquals( federateName, config.getFederateName() );
 		assertEquals( federateType, config.getFederateType() );
 		
-		assertEquals( expectedMaxReconnectAttempts, config.getMaxReconnectAttempts() );
-		assertEquals( expectedReconnectRetryInterval, config.getReconnectRetryInterval() );
+		assertEquals( expectedMaxReconnectAttempts, config.getMaxJoinAttempts() );
+		assertEquals( expectedReconnectRetryInterval, config.getJoinRetryInterval() );
 		assertEquals( expectedIsLateJoiner, config.isLateJoiner() );
 		assertEquals( expectedCallbacksAreEvoked, config.callbacksAreEvoked() );
 		assertEquals( expectedIsTimeStepped, config.isTimeStepped() );
@@ -219,14 +219,14 @@ public class FederateConfigurationTest extends TestCase
 		
 		FederateConfiguration config = new FederateConfiguration( federateName, federateType, federationName );
 		// sanity check that the default value is not our test value, otherwise this test is pointless
-		assertTrue( expectedMaxReconnectAttempts != config.getMaxReconnectAttempts() );
+		assertTrue( expectedMaxReconnectAttempts != config.getMaxJoinAttempts() );
 		// try changing the value
-		config.setMaxReconnectAttempts( expectedMaxReconnectAttempts );
-		assertEquals( expectedMaxReconnectAttempts, config.getMaxReconnectAttempts());
+		config.setMaxJoinAttempts( expectedMaxReconnectAttempts );
+		assertEquals( expectedMaxReconnectAttempts, config.getMaxJoinAttempts());
 		// freeze the config and try to change the value - should not change
 		config.freeze();
-		config.setMaxReconnectAttempts( expectedMaxReconnectAttempts + 1 );
-		assertEquals( expectedMaxReconnectAttempts, config.getMaxReconnectAttempts());
+		config.setMaxJoinAttempts( expectedMaxReconnectAttempts + 1 );
+		assertEquals( expectedMaxReconnectAttempts, config.getMaxJoinAttempts());
 	}
 	
 	/**
@@ -241,14 +241,14 @@ public class FederateConfigurationTest extends TestCase
 		
 		FederateConfiguration config = new FederateConfiguration( federateName, federateType, federationName );
 		// sanity check that the default value is not our test value, otherwise this test is pointless
-		assertTrue( expectedReconnectRetryInterval != config.getReconnectRetryInterval() );
+		assertTrue( expectedReconnectRetryInterval != config.getJoinRetryInterval() );
 		// try changing the value
-		config.setReconnectRetryInterval( expectedReconnectRetryInterval );
-		assertEquals( expectedReconnectRetryInterval, config.getReconnectRetryInterval());
+		config.setJoinRetryInterval( expectedReconnectRetryInterval );
+		assertEquals( expectedReconnectRetryInterval, config.getJoinRetryInterval());
 		// freeze the config and try to change the value - should not change
 		config.freeze();
-		config.setMaxReconnectAttempts( expectedReconnectRetryInterval + 1 );
-		assertEquals( expectedReconnectRetryInterval, config.getReconnectRetryInterval());
+		config.setMaxJoinAttempts( expectedReconnectRetryInterval + 1 );
+		assertEquals( expectedReconnectRetryInterval, config.getJoinRetryInterval());
 	}
 	
 	/**


### PR DESCRIPTION
- don't auto-achieve unknown (i.e., non-UCEF) synchronization points
- only synchronize before resignation if a `SimEnd` interaction had been received
- "immediate" response federate example; send interaction/reflection within the interaction/reflection receipt handler methods themselves (rather than storing in a queue to be handled later in the `step()` method, for example)