### PR TITLE
Updates to Support Type Querying

### DIFF
--- a/src/java/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
@@ -806,20 +806,20 @@ public abstract class FederateBase
 		Collection<ObjectClass> objectClasses = configuration.getPublishedAndSubscribedAttributes();
 		for(ObjectClass objectClass : objectClasses)
 		{
-			if(objectClass.publish)
+			if(objectClass.isPublished())
 			{
 				Set<String> attributes = objectClass.attributes.entrySet()
 					.stream()
-					.filter( x -> x.getValue().publish )
+					.filter( x -> x.getValue().isPublished() )
 					.map( x -> x.getValue().name )
 					.collect(Collectors.toSet());
 				rtiamb.publishObjectClassAttributes( objectClass.name, attributes );
 			}
-			if(objectClass.subscribe)
+			if(objectClass.isSubscribed())
 			{
 				Set<String> attributes = objectClass.attributes.entrySet()
 					.stream()
-					.filter( x -> x.getValue().subscribe )
+					.filter( x -> x.getValue().isSubscribed() )
 					.map( x -> x.getValue().name )
 					.collect(Collectors.toSet());
 				rtiamb.subscribeObjectClassAttributes( objectClass.name, attributes );
@@ -833,11 +833,11 @@ public abstract class FederateBase
 		
 		for(InteractionClass interactionClass : interactionClasses)
 		{
-			if(interactionClass.publish)
+			if(interactionClass.isPublished())
 			{
 				rtiamb.publishInteractionClass( interactionClass.name);
 			}
-			if(interactionClass.subscribe)
+			if(interactionClass.isSubscribed())
 			{
 				rtiamb.subscribeInteractionClass( interactionClass.name);
 			}

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
@@ -531,9 +531,6 @@ public abstract class FederateBase
 	{
 		beforeFederationJoin();
 
-		// no more configuration changes allowed
-		configuration.freeze();
-		
 		rtiamb.connect( fedamb, configuration.callbacksAreEvoked() );
 		
 		logger.info( "Federate {} connected to RTI.", configuration.getFederateName() );
@@ -803,7 +800,7 @@ public abstract class FederateBase
 	 */
 	protected void publishAndSubscribe()
 	{
-		Collection<ObjectClass> objectClasses = configuration.getPublishedAndSubscribedAttributes();
+		Collection<ObjectClass> objectClasses = configuration.getPublishedAndSubscribedObjectClasses();
 		for(ObjectClass objectClass : objectClasses)
 		{
 			if(objectClass.isPublished())

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/FederateConfiguration.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/FederateConfiguration.java
@@ -42,25 +42,20 @@ import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
 
 /**
- * The purpose of this class is to encapsulate all data required to configure a federate. The main
- * usage pattern is something like:
+ * The purpose of this class is to encapsulate all data required to configure a federate.
+ * 
+ * Most "setter" methods return the FederateConfiguratio instance to support method chaining.
+ * 
+ * The main usage pattern is something like:
  * 
  * 		FederateConfiguration config = new FederateConfiguration( "TheUnitedFederationOfPlanets", 
  * 		                                                          "FederateName", 
  * 		                                                          "TestFederate" );
- * 		config.addPublishedAttributes( publishedAttributes )
- * 			  .addSubscribedAttributes( subscribedAttributes )
- * 			  .addPublishedInteractions( publishedInteractions )
- * 			  .addSubscribedInteractions( publishedInteractions )
- * 			  .setLookAhead(0.5)
- * 			  .freeze();
- * 
- * Once "frozen", the configuration cannot be modified further - attempts to do so will result in
- * errors being logged, but there is no other "adverse" impact (apart from the attempted 
- * modification to the configuration not being applied).
- * 
- * The configuration should be frozen before being used to configure a federate, and most federates
- * will freeze the configuration when it is passed in to prevent modification.
+ * 		config.setLookAhead(0.5)
+ * 			.cacheInteractionClasses(
+ *              InteractionClass.Pub( PING_INTERACTION_ID ),
+ *              InteractionClass.Sub( PONG_INTERACTION_ID ) 
+ *          );
  */
 public class FederateConfiguration
 {
@@ -258,139 +253,6 @@ public class FederateConfiguration
 	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/**
-	 * Obtain the configured federation name
-	 * 
-	 * @return the configured federation name (not modifiable)
-	 */
-	public String getFederationName()
-	{
-		return federationExecName;
-	}
-
-	/**
-	 * Obtain the configured federate name
-	 * 
-	 * @return the configured federate name (not modifiable)
-	 */
-	public String getFederateName()
-	{
-		return federateName;
-	}
-
-	/**
-	 * Obtain the configured federate type
-	 * 
-	 * @return the configured federate type (not modifiable)
-	 */
-	public String getFederateType()
-	{
-		return federateType;
-	}
-
-	/**
-	 * Determine whether the federate should be able to create a required federation if it is
-	 * absent
-	 * 
-	 * @return true if the federate should be able to create federations, false otherwise
-	 */
-	public boolean canCreateFederation()
-	{
-		return canCreateFederation;
-	}
-	
-	/**
-	 * Obtain the maximum number of attempts to join a federation
-	 * 
-	 * @return the maximum number of attempts to join a federation
-	 */
-	public int getMaxJoinAttempts()
-	{
-		return maxJoinAttempts;
-	}
-
-	/**
-	 * Obtain the interval, in seconds, between attempts to join a federation
-	 * 
-	 * @return the interval, in seconds, between attempts to join a federation
-	 */
-	public long getJoinRetryInterval()
-	{
-		return joinRetryIntervalSec;
-	}
-
-	/**
-	 * Determine whether the federate should synchronize before resigning from the federation
-	 * 
-	 * @return true if the federate must synchronize before resigning from the federation, 
-	 *         otherwise it's OK to exit without synchronizing
-	 */
-	public boolean shouldSyncBeforeResign()
-	{
-		return syncBeforeResign;
-	}
-	
-	/**
-	 * Obtain the lookahead
-	 * 
-	 * @return the lookahead
-	 */
-	public double getLookAhead()
-	{
-		return lookAhead;
-	}
-
-	/**
-	 * Obtain the step size
-	 * 
-	 * @return the step size
-	 */
-	public double getStepSize()
-	{
-		return stepSize;
-	}
-
-	/**
-	 * Determine if the federate is configured to be time stepped
-	 * 
-	 * @return true if the federate is configured to be time stepped, false otherwise
-	 */
-	public boolean isTimeStepped()
-	{
-		return isTimeStepped;
-	}
-	
-	/**
-	 * Determine if the federate is configured to use evoked callbacks
-	 * 
-	 * @return true if the federate is configured to use evoked callbacks
-	 */
-	public boolean callbacksAreEvoked()
-	{
-		return callbacksAreEvoked;
-	}
-	
-	/**
-	 * Obtain the configured FOM modules
-	 * 
-	 * @return the configured FOM modules (not modifiable)
-	 */
-	public Collection<URL> getModules()
-	{
-		return Collections.unmodifiableSet( modules );
-	}
-
-	/**
-	 * Obtain the configured join FOM modules
-	 * 
-	 * @return the configured join FOM modules (not modifiable)
-	 */
-	public Collection<URL> getJoinModules()
-	{
-		return Collections.unmodifiableSet( joinModules );
-	}
-
-
-	/**
 	 * Set the federation execution name
 	 * 
 	 * @param federationExecName the federation execution name
@@ -400,6 +262,17 @@ public class FederateConfiguration
 		this.federationExecName = federationExecName;
 		return this;
 	}
+	
+	/**
+	 * Obtain the configured federation name
+	 * 
+	 * @return the configured federation name (not modifiable)
+	 */
+	public String getFederationName()
+	{
+		return federationExecName;
+	}
+
 	
 	/**
 	 * Set the federate name
@@ -413,6 +286,16 @@ public class FederateConfiguration
 	}
 	
 	/**
+	 * Obtain the configured federate name
+	 * 
+	 * @return the configured federate name (not modifiable)
+	 */
+	public String getFederateName()
+	{
+		return federateName;
+	}
+
+	/**
 	 * Set the federate type
 	 * 
 	 * @param federateType the federate type
@@ -423,6 +306,16 @@ public class FederateConfiguration
 		return this;
 	}
 	
+	/**
+	 * Obtain the configured federate type
+	 * 
+	 * @return the configured federate type (not modifiable)
+	 */
+	public String getFederateType()
+	{
+		return federateType;
+	}
+
 	/**
 	 * Configure whether the federate is able to create a federation if the federation is absent
 	 * on startup
@@ -438,6 +331,17 @@ public class FederateConfiguration
 	}
 	
 	/**
+	 * Determine whether the federate should be able to create a required federation if it is
+	 * absent
+	 * 
+	 * @return true if the federate should be able to create federations, false otherwise
+	 */
+	public boolean canCreateFederation()
+	{
+		return canCreateFederation;
+	}
+	
+	/**
 	 * Configure the federate's maximum number of attempts to join a federation
 	 * 
 	 * @param maxJoinAttempts the maximum number of attempts to join a federation
@@ -450,6 +354,16 @@ public class FederateConfiguration
 	}
 
 	/**
+	 * Obtain the maximum number of attempts to join a federation
+	 * 
+	 * @return the maximum number of attempts to join a federation
+	 */
+	public int getMaxJoinAttempts()
+	{
+		return maxJoinAttempts;
+	}
+
+	/**
 	 * Configure the interval, in seconds, between attempts to join a federation
 	 * 
 	 * @param retryIntervalSec the interval, in seconds, between attempts to join a federation
@@ -459,6 +373,16 @@ public class FederateConfiguration
 	{
 		this.joinRetryIntervalSec = retryIntervalSec;
 		return this;
+	}
+
+	/**
+	 * Obtain the interval, in seconds, between attempts to join a federation
+	 * 
+	 * @return the interval, in seconds, between attempts to join a federation
+	 */
+	public long getJoinRetryInterval()
+	{
+		return joinRetryIntervalSec;
 	}
 
 	/**
@@ -475,6 +399,17 @@ public class FederateConfiguration
 	}
 	
 	/**
+	 * Determine whether the federate should synchronize before resigning from the federation
+	 * 
+	 * @return true if the federate must synchronize before resigning from the federation, 
+	 *         otherwise it's OK to exit without synchronizing
+	 */
+	public boolean shouldSyncBeforeResign()
+	{
+		return syncBeforeResign;
+	}
+	
+	/**
 	 * Configure the federate's lookahead
 	 * 
 	 * @param lookAhead the lookahead
@@ -485,6 +420,16 @@ public class FederateConfiguration
 		this.lookAhead = lookAhead;
 		return this;
 	}
+	/**
+	 * Obtain the lookahead
+	 * 
+	 * @return the lookahead
+	 */
+	public double getLookAhead()
+	{
+		return lookAhead;
+	}
+
 
 	/**
 	 * Configure the federate's step size
@@ -496,6 +441,16 @@ public class FederateConfiguration
 	{
 		this.stepSize = stepSize;
 		return this;
+	}
+
+	/**
+	 * Obtain the step size
+	 * 
+	 * @return the step size
+	 */
+	public double getStepSize()
+	{
+		return stepSize;
 	}
 
 	/**
@@ -511,6 +466,16 @@ public class FederateConfiguration
 	}
 	
 	/**
+	 * Determine if the federate is configured to be time stepped
+	 * 
+	 * @return true if the federate is configured to be time stepped, false otherwise
+	 */
+	public boolean isTimeStepped()
+	{
+		return isTimeStepped;
+	}
+	
+	/**
 	 * Configure whether the federate is configured to use evoked callbacks
 	 * 
 	 * @param callbacksAreEvoked true if the federate is configured to use evoked callbacks, false otherwise
@@ -520,6 +485,16 @@ public class FederateConfiguration
 	{
 		this.callbacksAreEvoked = callbacksAreEvoked;
 		return this;
+	}
+	
+	/**
+	 * Determine if the federate is configured to use evoked callbacks
+	 * 
+	 * @return true if the federate is configured to use evoked callbacks
+	 */
+	public boolean callbacksAreEvoked()
+	{
+		return callbacksAreEvoked;
 	}
 	
 	/**
@@ -560,6 +535,16 @@ public class FederateConfiguration
 	}
 
 	/**
+	 * Obtain the configured FOM modules
+	 * 
+	 * @return the configured FOM modules (not modifiable)
+	 */
+	public Collection<URL> getModules()
+	{
+		return Collections.unmodifiableSet( modules );
+	}
+
+	/**
 	 * Add a join FOM module to the configuration
 	 * 
 	 * @param joinModule the join FOM module to add to the configuration
@@ -594,6 +579,16 @@ public class FederateConfiguration
 			this.joinModules.addAll( collectNonEmptyURLs( joinModules ) );
 		}
 		return this;
+	}
+	
+	/**
+	 * Obtain the configured join FOM modules
+	 * 
+	 * @return the configured join FOM modules (not modifiable)
+	 */
+	public Collection<URL> getJoinModules()
+	{
+		return Collections.unmodifiableSet( joinModules );
 	}
 	
 	public Set<String> getFomPaths()
@@ -690,9 +685,9 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Obtain the published *and* subscribed interactions
+	 * Obtain the interactions which are both published *and* subscribed by this federate
 	 * 
-	 * @return the published *and* subscribed interactions (not modifiable)
+	 * @return the interactions which are both published *and* subscribed (not modifiable)
 	 */
 	public Collection<Types.InteractionClass> getPublishedAndSubscribedInteractions()
 	{
@@ -700,7 +695,7 @@ public class FederateConfiguration
 	}
 	
 	/**
-	 * Obtain the published interactions
+	 * Obtain the interactions which are published by this federate.
 	 * 
 	 * @return the published interactions (not modifiable)
 	 */
@@ -713,7 +708,7 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Obtain the subscribed interactions
+	 * Obtain the interactions which are subscribed to by this federate.
 	 * 
 	 * @return the subscribed interactions (not modifiable)
 	 */
@@ -726,9 +721,9 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Obtain the published *and* subscribed attributes
+	 * Obtain the object classes which are both published *and* subscribed by this federate.
 	 * 
-	 * @return the published *and* subscribed attributes (not modifiable)
+	 * @return the object classes which are both published *and* subscribed (not modifiable)
 	 */
 	public Collection<Types.ObjectClass> getPublishedAndSubscribedObjectClasses()
 	{
@@ -736,9 +731,9 @@ public class FederateConfiguration
 	}
 	
 	/**
-	 * Obtain the published attributes
+	 * Obtain the object classes which are published by this federate.
 	 * 
-	 * @return the published attributes (not modifiable)
+	 * @return Obtain the object classes which are published (not modifiable)
 	 */
 	public Collection<Types.ObjectClass> getPublishedObjectClasses()
 	{
@@ -749,9 +744,9 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Obtain the subscribed attributes
+	 * Obtain the object classes which are subscribed to by this federate.
 	 * 
-	 * @return the subscribed attributes (not modifiable)
+	 * @return the object classes which are subscribed (not modifiable)
 	 */
 	public Collection<Types.ObjectClass> getSubscribedObjectClasses()
 	{
@@ -762,10 +757,10 @@ public class FederateConfiguration
 	}
 	
 	/**
-	 * Returns the fully qualified names of the interaction classes that are published by this
+	 * Returns the fully qualified names of the interaction classes which are published by this
 	 * federate.
 	 *
-	 * @return the names of the publishing interaction classes (not modifiable)
+	 * @return the names of the published interaction classes (not modifiable)
 	 */
 	public Set<String> getPublishedInteractionNames()
 	{
@@ -776,8 +771,8 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Returns the fully qualified names of the interaction classes that are subscribed by this
-	 * federate.
+	 * Returns the fully qualified names of the interaction classes which are subscribed to by
+	 * this federate.
 	 *
 	 * @return the names of the subscribed interaction classes (not modifiable)
 	 */
@@ -790,10 +785,13 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Returns the names of the publishing attributes of a given object class
+	 * Obtain the names of the published attributes of a given object class.
+	 * 
+	 * If no object class can be resolved from the given fully qualified object class name, an
+	 * empty {@link Set} is returned.
 	 *
-	 * @param className the name of a object class
-	 * @return publishing attributes of the given object class (not modifiable)
+	 * @param className the fully qualified name of an object class
+	 * @return published attributes of the given object class (not modifiable)
 	 */
 	public Set<String> getPublishedAttributeNames( String className )
 	{
@@ -810,9 +808,12 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Returns the names of the subscribed attributes of a given object class
+	 * Obtain the names of the subscribed attributes of a given object class.
+	 * 
+	 * If no object class can be resolved from the given fully qualified object class name, an
+	 * empty {@link Set} is returned.
 	 *
-	 * @param className the name of a object class
+	 * @param className the fully qualified name of an object class
 	 * @return subscribed attributes of the given object class (not modifiable)
 	 */
 	public Set<String> getSubscribedAttributeNames( String className )
@@ -830,9 +831,12 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Returns parameter names of a given interaction class
+	 * Obtain the names of the parameters of a given interaction class.
+	 * 
+	 * If no interaction class can be resolved from the given fully qualified interaction class
+	 * name, an empty {@link Set} is returned.
 	 *
-	 * @param interactionName the name of a interaction class
+	 * @param interactionName the fully qualified name of a interaction class
 	 * @return parameter names of the given interaction class (not modifiable)
 	 */
 	public Set<String> getParameterNames( String interactionName )
@@ -846,10 +850,9 @@ public class FederateConfiguration
 	}
 
 	/**
-	 * Returns the fully qualified names of the object classes that are published by this
-	 * federate.
-	 *
-	 * @return the names of the publishing object classes (not modifiable)
+	 * Obtain the fully qualified names of all object classes published by this federate.
+	 * 
+	 * @return the fully qualified names of the published object classes (not modifiable)
 	 */
 	public Set<String> getPublishedClassNames()
 	{
@@ -859,12 +862,10 @@ public class FederateConfiguration
 			.collect(Collectors.toSet());
 	}
 
-
 	/**
-	 * Returns the fully qualified names of the object classes that are subscribed by this
-	 * federate.
-	 *
-	 * @return the names of the subscribed object classes (not modifiable)
+	 * Obtain the fully qualified names of all object classes subscribed to by this federate.
+	 * 
+	 * @return the fully qualified names of the subscribed object classes (not modifiable)
 	 */
 	public Set<String> getSubscribedClassNames()
 	{
@@ -875,11 +876,21 @@ public class FederateConfiguration
 	}
 	
 	/**
-	 * Returns the data type of the given attribute or parameter
+	 * Returns the data type of the an object class attribute or interaction parameter given the
+	 * fully qualified name and member name
 	 * 
-	 * If the data type cannot be resolved, {@link DataType#UNKNOWN} will be returned
+	 * If the data type cannot be resolved, {@link DataType#UNKNOWN} will be returned.
+	 * 
+	 * NOTE: The fully qualified name of an interaction or object class includes the
+	 * `HLAobjectRoot` or `HLAinteractionRoot` namespace. This means is not possible for names of
+	 * interactions and object classes to collide (even if the "local" name for an interaction and
+	 * object class were to coincide). For this reason, it is not necessary to specify whether the
+	 * fully qualified class name refers to an interaction or object class, since it will only
+	 * ever match *either* an interaction *or* an object class.
 	 *
-	 * @param className the name of an object or an interaction class
+	 * @param className the fully qualified name of an object or an interaction class
+	 * @param memberName the name of an attribute or parameter on the object class or interaction
+	 *            referenced by the fully qualified class name
 	 * @return the data type of attribute or parameter matching the provided name for of the given
 	 *         object/interaction class
 	 */
@@ -894,7 +905,7 @@ public class FederateConfiguration
 			return parameter == null ? DataType.UNKNOWN : parameter.dataType;
 		}
 		
-		// no interaction - try for an object class matching the class name
+		// no interaction match - try to match on known object classes...
 		ObjectClass objectClass = this.objectClassesByName.get( className );
 		if( objectClass != null )
 		{
@@ -903,7 +914,8 @@ public class FederateConfiguration
 			return attribute == null ? DataType.UNKNOWN : attribute.dataType;
 		}
 		
-		// no interaction or object class found matching the provided class name
+		// no interaction or object class found matching the provided 
+		// fully qualified class name
 		return DataType.UNKNOWN;
 	}
 		

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/HLAInteraction.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/HLAInteraction.java
@@ -143,7 +143,7 @@ public class HLAInteraction
 	 * @param parameterName the name of the parameter
 	 * @return true if the parameter is known by this instance, false otherwise
 	 */
-	public boolean hasParameter( String parameterName )
+	public boolean isParameter( String parameterName )
 	{
 		return this.parameters.containsKey( parameterName );
 	}

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/SOMParser.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/SOMParser.java
@@ -234,20 +234,20 @@ public class SOMParser
 	                                           Collection<ObjectAttribute> attributes)
 	{
 		String className = getTextValue( root, NAME );
-		String sharing = getTextValue( root, SHARING );
+		String sharingStr = getTextValue( root, SHARING );
 		
-		ObjectClass objectClass = new Types.ObjectClass(namespace + className);
-		objectClass.sharing = Sharing.fromLabel(sharing);
+		Sharing sharing = Sharing.fromLabel(sharingStr);
+		ObjectClass objectClass = new ObjectClass(namespace + className, sharing);
 
 		for(Element elm : getChildElementsByName( root, ATTRIBUTE ))
 		{
-			String attributeName    = getTextValue( elm, NAME );
-			String attributeSharing = getTextValue( elm, SHARING );
-			String attributeType    = getTextValue( elm, DATA_TYPE );
+			String attrName       = getTextValue( elm, NAME );
+			String attrSharingStr = getTextValue( elm, SHARING );
+			String attrTypeStr    = getTextValue( elm, DATA_TYPE );
 			
-			ObjectAttribute attribute = new ObjectAttribute( attributeName );
-			attribute.sharing   = Sharing.fromLabel(attributeSharing);
-			attribute.dataType  = DataType.fromLabel( attributeType );
+			Sharing attrSharing        = Sharing.fromLabel( attrSharingStr );
+			DataType attrDataType      = DataType.fromLabel( attrTypeStr );
+			ObjectAttribute attribute  = new ObjectAttribute( attrName, attrDataType, attrSharing );
 			
 			attributes.add(attribute);
 		}
@@ -291,18 +291,18 @@ public class SOMParser
 	                                                Collection<InteractionParameter> parameters )
 	{
 		String className = getTextValue( root, NAME );
-		String sharing = getTextValue( root, SHARING );
+		String sharingStr = getTextValue( root, SHARING );
 		
-		InteractionClass interactionClass = new InteractionClass(namespace + className);
-		interactionClass.sharing   = Sharing.fromLabel( sharing );
+		Sharing sharing   = Sharing.fromLabel( sharingStr );
+		InteractionClass interactionClass = new InteractionClass(namespace + className, sharing);
 
 		for(Element elm : getChildElementsByName( root, PARAMETER ))
 		{
 			String parameterName    = getTextValue( elm, NAME );
-			String parameterType    = getTextValue( elm, DATA_TYPE );
+			String parameterTypeStr = getTextValue( elm, DATA_TYPE );
 			
-			InteractionParameter parameter = new InteractionParameter( parameterName );
-			parameter.dataType  = DataType.fromLabel( parameterType );
+			DataType dataType = DataType.fromLabel( parameterTypeStr );
+			InteractionParameter parameter = new InteractionParameter( parameterName, dataType );
 			
 			parameters.add(parameter);
 		}

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/SOMParser.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/SOMParser.java
@@ -98,20 +98,12 @@ public class SOMParser
 		// get the <objects> element, which is directly under <objectModel>
 		Element objectsRoot = getElementByPath( objectModelNode, OBJECTS );
 		Collection<ObjectClass> reflections = extractObjectClasses( objectsRoot );
+		config.cacheObjectClasses(reflections);
 		
 		// get the <interactions> element, which is directly under <objectModel>
 		Element interactionsRoot = getElementByPath( objectModelNode, INTERACTIONS );
 		Collection<InteractionClass> interactions = extractInteractionClasses( interactionsRoot );
-		
-		for(ObjectClass objectClass : reflections)
-		{
-			config.addReflection(objectClass);
-		}
-		
-		for(InteractionClass interactionClass : interactions)
-		{
-			config.addInteraction(interactionClass);
-		}
+		config.cacheInteractionClasses(interactions);
 	}
 	
 	/**

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/Types.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/Types.java
@@ -47,10 +47,9 @@ public class Types
 	//                      ENUMERATIONS
 	//----------------------------------------------------------
 	/**
-	 *  Represents data type of an attribute or interaction parameter
+	 * Represents the sharing type of an object class, object class attribute or interaction
 	 *
-	 *  @see ObjectAttribute
-	 *  @see InteractionParameter
+	 * See also: {@link ObjectClass}, {@link ObjectAttribute} and {@link InteractionClass}
 	 */
 	public enum Sharing
 	{
@@ -68,26 +67,43 @@ public class Types
 		
 		public String label;
 		
-		Sharing( String label )
+		private Sharing( String label )
 		{
 			this.label = label;
 		}
 		
+		@Override
 		public String toString()
 		{
 			return this.label;
 		}
 		
+		/**
+		 * Determine if this sharing policy includes publishing
+		 * 
+		 * @return true if this sharing policy includes publishing, false otherwise
+		 */
 		public boolean isPublish()
 		{
 			return this.equals( PUBLISH ) || this.equals( PUBLISHSUBSCRIBE );
 		}
 		
+		/**
+		 * Determine if this sharing policy includes subscribing
+		 * 
+		 * @return true if this sharing policy includes subscribing, false otherwise
+		 */
 		public boolean isSubscribe()
 		{
 			return this.equals( SUBSCRIBE ) || this.equals( PUBLISHSUBSCRIBE );
 		}
 		
+		/**
+		 * Determine if this sharing policy is neither for publishing nor for subscribing
+		 * 
+		 * @return true if this sharing policy is neither for publishing nor for subscribing,
+		 *         false otherwise
+		 */
 		public boolean isNeither()
 		{
 			return this.equals( NEITHER );
@@ -124,10 +140,9 @@ public class Types
 	};
 	
 	/**
-	 *  Represents data type of an attribute or interaction parameter
+	 * Represents data type of an attribute or interaction parameter
 	 *
-	 *  @see ObjectAttribute
-	 *  @see InteractionParameter
+	 * See also {@link ObjectAttribute} and {@link InteractionParameter}
 	 */
 	@SuppressWarnings("rawtypes")
 	public enum DataType
@@ -152,13 +167,14 @@ public class Types
 		public Class javaType;
 		public Class hlaType;
 		
-		DataType( String label, Class javaType, Class hlaType )
+		private DataType( String label, Class javaType, Class hlaType )
 		{
 			this.label = label;
 			this.javaType = javaType;
 			this.hlaType = hlaType;
 		}
 		
+		@Override
 		public String toString()
 		{
 			return this.label;
@@ -195,42 +211,31 @@ public class Types
 	};
 
 	//----------------------------------------------------------
-	//                   INSTANCE VARIABLES
-	//----------------------------------------------------------
-
-	//----------------------------------------------------------
-	//                      CONSTRUCTORS
-	//----------------------------------------------------------
-
-	//----------------------------------------------------------
-	//                    INSTANCE METHODS
-	//----------------------------------------------------------
-
-	
-	////////////////////////////////////////////////////////////////////////////////////////////
-	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
-	////////////////////////////////////////////////////////////////////////////////////////////
-
-	//----------------------------------------------------------
-	//                     STATIC METHODS
+	//                     CLASSES
 	//----------------------------------------------------------
 	/**
 	 * Represents an object class in a Simulation Object Model
 	 *
-	 * @see SOMParser#getObjectClasses(string&)
-	 * @see ObjectAttribute
+	 * See also {@link ObjectAttribute}
 	 */
 	public static class ObjectClass
 	{
+		//----------------------------------------------------------
+		//                   INSTANCE VARIABLES
+		//----------------------------------------------------------
 		public String name; // fully qualified object class name
 		public Sharing sharing;
 		Map<String,ObjectAttribute> attributes;
 
-		public ObjectClass( String name )
-		{
-			this(name, Sharing.NEITHER);
-		}
-		
+		//----------------------------------------------------------
+		//                      CONSTRUCTORS
+		//----------------------------------------------------------
+		/**
+		 * Constructor
+		 * 
+		 * @param name the fully qualified object class name
+		 * @param sharing the sharing type
+		 */
 		public ObjectClass( String name, Sharing sharing )
 		{
 			this.name = name;
@@ -238,54 +243,182 @@ public class Types
 			this.attributes = new HashMap<>();
 		}
 		
+		//----------------------------------------------------------
+		//                    INSTANCE METHODS
+		//----------------------------------------------------------
+		@Override
+		public String toString()
+		{
+			String attrs = this.attributes.values()
+				.stream()
+				.map((attribute)->attribute.toString())
+				.collect(Collectors.joining(","));
+			
+			return String.format( "Class:'%s'(%s){%s}",
+			                      this.name, this.sharing.toString(), attrs );
+		}
+
+		////////////////////////////////////////////////////////////////////////////////////////////
+		/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+		////////////////////////////////////////////////////////////////////////////////////////////
+		/**
+		 * Determine if the sharing policy for this instance includes publishing
+		 * 
+		 * @return if the sharing policy for this instance includes publishing, false otherwise
+		 */
 		public boolean isPublished()
 		{
 			return this.sharing.isPublish();
 		}
 		
+		/**
+		 * Determine if the sharing policy for this instance includes subscribing
+		 * 
+		 * @return if the sharing policy for this instance includes subscribing, false otherwise
+		 */
 		public boolean isSubscribed()
 		{
 			return this.sharing.isSubscribe();
 		}
 		
-		public void addAttribute( ObjectAttribute attribute )
+		/**
+		 * Add an attribute instance
+		 * 
+		 * @param attribute the {@link ObjectAttribute} instance to be added
+		 * @return the added {@link ObjectAttribute} instance
+		 */
+		public ObjectAttribute addAttribute( ObjectAttribute attribute )
 		{
 			this.attributes.put( attribute.name, attribute );
+			return attribute;
 		}
 		
+		/**
+		 * Add an attribute with the given name, data type and sharing policy
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @param sharing the sharing policy for this attribute
+		 * @return the added {@link ObjectAttribute} instance
+		 */
+		public ObjectAttribute addAttribute( String name, DataType dataType, Sharing sharing )
+		{
+			return addAttribute( new ObjectAttribute( name, dataType, sharing ) );
+		}
+		
+		/**
+		 * Shortcut method for adding attributes which are published
+		 * 
+		 * See also {@link #addAttribute(String, DataType, Sharing)}
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return the added {@link ObjectAttribute} instance
+		 */
+		public ObjectAttribute addAttributePub( String name, DataType dataType )
+		{
+			return addAttribute( name, dataType, Sharing.PUBLISH );
+		}
+		
+		/**
+		 * Shortcut method for adding attributes which are subscribed
+		 * See also {@link #addAttribute(String, DataType, Sharing)}
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return the added {@link ObjectAttribute} instance
+		 */
+		public ObjectAttribute addAttributeSub( String name, DataType dataType )
+		{
+			return addAttribute( name, dataType, Sharing.SUBSCRIBE );
+		}
+		
+		/**
+		 * Shortcut method for adding attributes which are both published and subscribed
+		 * 
+		 * See also {@link #addAttribute(String, DataType, Sharing)}
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return the added {@link ObjectAttribute} instance
+		 */
+		public ObjectAttribute addAttributePubSub( String name, DataType dataType )
+		{
+			return addAttribute( name, dataType, Sharing.PUBLISHSUBSCRIBE );
+		}
+		
+		/**
+		 * Obtain the attributes of this instance
+		 * 
+		 * @return a {@link Map} relating the names of the attributes to their corresponding
+		 *         {@link ObjectAttribute} definition instances
+		 */
 		public Map<String,ObjectAttribute> getAttributes()
 		{
 			return Collections.unmodifiableMap( this.attributes );
 		}
 		
-		public String toString()
+		//----------------------------------------------------------
+		//                     STATIC METHODS
+		//----------------------------------------------------------
+		/**
+		 * "Shortcut" static method to create published instances
+		 * 
+		 * See also {@link ObjectClass(String, Sharing)}
+		 * 
+		 * @param name the fully qualified object class name
+		 * @return an {@link ObjectClass} instance with a {@link Sharing#PUBLISH} sharing policy
+		 */
+		public static ObjectClass Pub( String name )
 		{
-			String attrs = this.attributes.values()
-				.stream()
-				.map((m)->m.toString())
-				.collect(Collectors.joining(","));
-			
-			return String.format( "Class:'%s'(%s){%s}",
-			                      this.name, this.sharing.toString(), attrs );
+			return new ObjectClass( name, Sharing.PUBLISH );
+		}
+
+		/**
+		 * "Shortcut" static method to create subscribed instances
+		 * 
+		 * See also {@link ObjectClass(String, Sharing)}
+		 * 
+		 * @param name the fully qualified object class name
+		 * @return an {@link ObjectClass} instance with a {@link Sharing#SUBSCRIBE} sharing policy
+		 */
+		public static ObjectClass Sub( String name )
+		{
+			return new ObjectClass( name, Sharing.SUBSCRIBE );
+		}
+
+		/**
+		 * "Shortcut" static method to create instances which are both published and subscribed
+		 * 
+		 * See also {@link ObjectClass(String, Sharing)}
+		 * 
+		 * @param name the fully qualified object class name
+		 * @return an {@link ObjectClass} instance with a {@link Sharing#PUBLISHSUBSCRIBE} sharing
+		 *         policy
+		 */
+		public static ObjectClass PubSub( String name )
+		{
+			return new ObjectClass( name, Sharing.PUBLISHSUBSCRIBE );
 		}
 	}
 
 	/**
 	 * Represents an attribute in an object class in a Simulation Object Model
 	 *
-	 * @see ObjectClass
+	 * See also {@link ObjectClass}
 	 */
 	public static class ObjectAttribute
 	{
+		//----------------------------------------------------------
+		//                   INSTANCE VARIABLES
+		//----------------------------------------------------------
 		public String name;
 		public Sharing sharing;
 		public DataType dataType;
 
-		public ObjectAttribute( String name )
-		{
-			this(name, DataType.UNKNOWN, Sharing.NEITHER);
-		}
-		
+		//----------------------------------------------------------
+		//                      CONSTRUCTORS
+		//----------------------------------------------------------
 		public ObjectAttribute( String name, DataType dataType, Sharing sharing )
 		{
 			this.name = name;
@@ -293,16 +426,10 @@ public class Types
 			this.dataType = dataType == null ? DataType.UNKNOWN : dataType;
 		}
 		
-		public boolean isPublished()
-		{
-			return this.sharing.isPublish();
-		}
-		
-		public boolean isSubscribed()
-		{
-			return this.sharing.isSubscribe();
-		}
-		
+		//----------------------------------------------------------
+		//                    INSTANCE METHODS
+		//----------------------------------------------------------
+		@Override
 		public String toString()
 		{
 			return String.format( "Attr:'%s'[%s](%s)",
@@ -310,26 +437,96 @@ public class Types
 			                      this.dataType.toString(),
 			                      this.sharing.toString());
 		}
+		
+		////////////////////////////////////////////////////////////////////////////////////////////
+		/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+		////////////////////////////////////////////////////////////////////////////////////////////
+		/**
+		 * Determine if the sharing policy for this instance includes publishing
+		 * 
+		 * @return if the sharing policy for this instance includes publishing, false otherwise
+		 */
+		public boolean isPublished()
+		{
+			return this.sharing.isPublish();
+		}
+		
+		/**
+		 * Determine if the sharing policy for this instance includes subscribing
+		 * 
+		 * @return if the sharing policy for this instance includes subscribing, false otherwise
+		 */
+		public boolean isSubscribed()
+		{
+			return this.sharing.isSubscribe();
+		}
+
+		//----------------------------------------------------------
+		//                     STATIC METHODS
+		//----------------------------------------------------------
+		/**
+		 * "Shortcut" static method to create published instances
+		 * 
+		 * See also {@link ObjectAttribute(String, DataType, Sharing)}
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return an {@link ObjectAttribute} instance with a {@link Sharing#PUBLISH} sharing
+		 *         policy
+		 */
+		public static ObjectAttribute Pub( String name, DataType dataType )
+		{
+			return new ObjectAttribute( name, dataType, Sharing.PUBLISH );
+		}
+		
+		/**
+		 * "Shortcut" static method to create subscribed instances
+		 * 
+		 * See also {@link ObjectAttribute(String, DataType, Sharing)}
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return an {@link ObjectAttribute} instance with a {@link Sharing#SUBSCRIBE} sharing
+		 *         policy
+		 */
+		public static ObjectAttribute Sub( String name, DataType dataType )
+		{
+			return new ObjectAttribute( name, dataType, Sharing.SUBSCRIBE );
+		}
+		
+		/**
+		 * "Shortcut" static method to create instances which are both published and subscribed
+		 * 
+		 * See also {@link ObjectAttribute(String, DataType, Sharing)}
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return an {@link ObjectAttribute} instance with a {@link Sharing#PUBLISHSUBSCRIBE}
+		 *         sharing policy
+		 */
+		public static ObjectAttribute PubSub( String name, DataType dataType )
+		{
+			return new ObjectAttribute( name, dataType, Sharing.PUBLISHSUBSCRIBE );
+		}		
 	}
 
 	/**
 	 * Represents an interaction class in a Simulation Object Model
 	 *
-	 * @see SOMParser#getInteractionClasses(string&)
-	 * @see InteractionParameter
+	 * See also {@link InteractionParameter}
 	 */
 	public static class InteractionClass
 	{
+		//----------------------------------------------------------
+		//                   INSTANCE VARIABLES
+		//----------------------------------------------------------
 		public String name; // fully qualified interaction class name
 		public Sharing sharing;
 		public Map<String,InteractionParameter> parameters;
 
-		public InteractionClass( String name )
-		{
-			this( name, Sharing.NEITHER );
-			this.parameters = new HashMap<>();
-		}
-		
+		//----------------------------------------------------------
+		//                      CONSTRUCTORS
+		//----------------------------------------------------------
 		public InteractionClass( String name, Sharing sharing )
 		{
 			this.name = name;
@@ -337,59 +534,144 @@ public class Types
 			this.parameters = new HashMap<>();
 		}
 		
+		//----------------------------------------------------------
+		//                    INSTANCE METHODS
+		//----------------------------------------------------------
+		@Override
+		public String toString()
+		{
+			String params = this.parameters.values()
+				.stream()
+				.map((parameter)->parameter.toString())
+				.collect(Collectors.joining(","));
+			
+			return String.format( "Interaction:'%s'(%s){%s}",
+			                      this.name, this.sharing.toString(), params );
+		}
+		
+		////////////////////////////////////////////////////////////////////////////////////////////
+		/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
+		////////////////////////////////////////////////////////////////////////////////////////////
+		/**
+		 * Determine if the sharing policy for this instance includes publishing
+		 * 
+		 * @return if the sharing policy for this instance includes publishing, false otherwise
+		 */
 		public boolean isPublished()
 		{
 			return this.sharing.isPublish();
 		}
 		
+		/**
+		 * Determine if the sharing policy for this instance includes subscribing
+		 * 
+		 * @return if the sharing policy for this instance includes subscribing, false otherwise
+		 */
 		public boolean isSubscribed()
 		{
 			return this.sharing.isSubscribe();
 		}
-		
-		public void addParameter( InteractionParameter parameter )
+
+		/**
+		 * Add an parameter instance
+		 * 
+		 * @param parameter the {@link InteractionParameter} instance to be added
+		 * @return the added {@link InteractionParameter} instance
+		 */
+		public InteractionParameter addParameter( InteractionParameter parameter )
 		{
 			this.parameters.put( parameter.name, parameter );
+			return parameter;
+		}
+		
+		/**
+		 * Add a parameter with the given name and data type
+		 * 
+		 * @param name the attribute name
+		 * @param dataType the attribute data type
+		 * @return the added {@link InteractionParameter} instance
+		 */
+		public InteractionParameter addParameter( String name, DataType datatType )
+		{
+			return addParameter( new InteractionParameter( name, datatType ) );
 		}
 		
 		public Map<String,InteractionParameter> getParameters()
 		{
 			return Collections.unmodifiableMap( this.parameters );
 		}
-		
-		public String toString()
+		//----------------------------------------------------------
+		//                     STATIC METHODS
+		//----------------------------------------------------------
+		/**
+		 * "Shortcut" static method to create instances which are published
+		 * 
+		 * See also {@link InteractionClass(String, Sharing)}
+		 * 
+		 * @param name the fully qualified interaction class name
+		 * @return an {@link InteractionClass} instance with a {@link Sharing#PUBLISH} sharing
+		 *         policy
+		 */
+		public static InteractionClass Pub( String name )
 		{
-			String params = this.parameters.values()
-				.stream()
-				.map((m)->m.toString())
-				.collect(Collectors.joining(","));
-			
-			return String.format( "Interaction:'%s'(%s){%s}",
-			                      this.name, this.sharing.toString(), params );
+			return new InteractionClass( name, Sharing.PUBLISH );
+		}
+		
+		/**
+		 * "Shortcut" static method to create instances which are subscribed
+		 * 
+		 * See also {@link InteractionClass(String, Sharing)}
+		 * 
+		 * @param name the fully qualified interaction class name
+		 * @return an {@link InteractionClass} instance with a {@link Sharing#SUBSCRIBE} sharing
+		 *         policy
+		 */
+		public static InteractionClass Sub( String name )
+		{
+			return new InteractionClass( name, Sharing.SUBSCRIBE );
+		}
+		
+		/**
+		 * "Shortcut" static method to create instances which are both published and subscribed
+		 * 
+		 * See also {@link InteractionClass(String, Sharing)}
+		 * 
+		 * @param name the fully qualified interaction class name
+		 * @return an {@link InteractionClass} instance with a {@link Sharing#PUBLISHSUBSCRIBE} sharing
+		 *         policy
+		 */
+		public static InteractionClass PubSub( String name )
+		{
+			return new InteractionClass( name, Sharing.PUBLISHSUBSCRIBE );
 		}
 	}
 	
 	/**
 	 * Represents a parameter in an interaction class in a Simulation Object Model
 	 *
-	 * @see InteractionClass
+	 * See also {@link InteractionClass}
 	 */
 	public static class InteractionParameter
 	{
+		//----------------------------------------------------------
+		//                   INSTANCE VARIABLES
+		//----------------------------------------------------------
 		public String name;
 		public DataType dataType;
 
-		public InteractionParameter( String name )
-		{
-			this( name, DataType.UNKNOWN );
-		}
-
+		//----------------------------------------------------------
+		//                      CONSTRUCTORS
+		//----------------------------------------------------------
 		public InteractionParameter( String name, DataType dataType )
 		{
 			this.name = name;
 			this.dataType = dataType == null ? DataType.UNKNOWN : dataType;
 		}
 		
+		//----------------------------------------------------------
+		//                    INSTANCE METHODS
+		//----------------------------------------------------------
+		@Override
 		public String toString()
 		{
 			return String.format( "Param:'%s'[%s]",

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/Types.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/Types.java
@@ -253,6 +253,11 @@ public class Types
 			this.attributes.put( attribute.name, attribute );
 		}
 		
+		public Map<String,ObjectAttribute> getAttributes()
+		{
+			return Collections.unmodifiableMap( this.attributes );
+		}
+		
 		public String toString()
 		{
 			String attrs = this.attributes.values()
@@ -345,6 +350,11 @@ public class Types
 		public void addParameter( InteractionParameter parameter )
 		{
 			this.parameters.put( parameter.name, parameter );
+		}
+		
+		public Map<String,InteractionParameter> getParameters()
+		{
+			return Collections.unmodifiableMap( this.parameters );
 		}
 		
 		public String toString()

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/base/PingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/base/PingFederate.java
@@ -31,6 +31,8 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
+import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.util.Constants;
@@ -220,8 +222,11 @@ public class PingFederate extends FederateBase
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( PING_INTERACTION_ID );
-		config.addSubscribedInteraction( PONG_INTERACTION_ID );
+		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
+		                                                                    Sharing.PUBLISH);
+		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
+		                                                                    Sharing.SUBSCRIBE);
+		config.addInteractions( pingInteraction, pongInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/base/PingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/base/PingFederate.java
@@ -32,7 +32,6 @@ import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.util.Constants;
@@ -223,8 +222,8 @@ public class PingFederate extends FederateBase
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass( PING_INTERACTION_ID, Sharing.PUBLISH ),
-            new InteractionClass( PONG_INTERACTION_ID, Sharing.SUBSCRIBE )
+            InteractionClass.Pub( PING_INTERACTION_ID ),
+            InteractionClass.Sub( PONG_INTERACTION_ID )
         );
 
 		// somebody set us up the FOM...

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/base/PingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/base/PingFederate.java
@@ -31,7 +31,7 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
-import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
 import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
@@ -221,12 +221,11 @@ public class PingFederate extends FederateBase
 		config.setFederateType( "PingFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of interactions to be published and subscribed to
-		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
-		                                                                    Sharing.PUBLISH);
-		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
-		                                                                    Sharing.SUBSCRIBE);
-		config.addInteractions( pingInteraction, pongInteraction );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass( PING_INTERACTION_ID, Sharing.PUBLISH ),
+            new InteractionClass( PONG_INTERACTION_ID, Sharing.SUBSCRIBE )
+        );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/base/PongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/base/PongFederate.java
@@ -31,8 +31,10 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
+import gov.nist.ucef.hla.base.Types;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.util.Constants;
 import gov.nist.ucef.hla.util.FileUtils;
 import hla.rti1516e.encoding.EncoderFactory;
@@ -220,8 +222,11 @@ public class PongFederate extends FederateBase
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( PONG_INTERACTION_ID );
-		config.addSubscribedInteraction( PING_INTERACTION_ID );
+		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
+		                                                                    Sharing.PUBLISH);
+		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
+		                                                                    Sharing.SUBSCRIBE);
+		config.addInteractions( pongInteraction, pingInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/base/PongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/base/PongFederate.java
@@ -31,10 +31,10 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
-import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.util.Constants;
 import gov.nist.ucef.hla.util.FileUtils;
 import hla.rti1516e.encoding.EncoderFactory;
@@ -221,13 +221,12 @@ public class PongFederate extends FederateBase
 		config.setFederateType( "PongFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of interactions to be published and subscribed to
-		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
-		                                                                    Sharing.PUBLISH);
-		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
-		                                                                    Sharing.SUBSCRIBE);
-		config.addInteractions( pongInteraction, pingInteraction );
-
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+           	new InteractionClass( PONG_INTERACTION_ID, Sharing.PUBLISH ),
+            new InteractionClass( PING_INTERACTION_ID, Sharing.SUBSCRIBE )
+        );
+		
 		// somebody set us up the FOM...
 		try
 		{

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/ChallengerManager.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/ChallengerManager.java
@@ -25,6 +25,11 @@ package gov.nist.ucef.hla.example.challenger;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.UCEFException;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.example.fedman.FedManConstants;
 import gov.nist.ucef.hla.example.fedman.FedManFederate;
 import gov.nist.ucef.hla.ucef.SimEnd;
@@ -116,13 +121,27 @@ public class ChallengerManager
 		// a federation manager is allowed to create a required federation
 		config.setCanCreateFederation( true );
 
-		// subscribe to reflections described in MIM to detected joining federates 
-		config.addSubscribedAttributes( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME, 
-		                                FedManConstants.HLAFEDERATE_ATTRIBUTE_NAMES );
-		// published UCEF interactions
-		config.addPublishedInteractions( SimPause.interactionName(),
-		                                 SimResume.interactionName(),
-		                                 SimEnd.interactionName() );
+		// set up object class reflections to subscribe to (described 
+		// in MIM) to detect joining federates. Note that since this
+		// is a non-UCEF reflection, the `DataType` parameter here 
+		// does not really matter too much
+		ObjectClass mimReflection = new ObjectClass( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME, 
+		                                             Sharing.SUBSCRIBE );
+		for( String attributeName : FedManConstants.HLAFEDERATE_ATTRIBUTE_NAMES )
+		{
+			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
+			                                                       DataType.UNKNOWN, 
+			                                                       Sharing.SUBSCRIBE );
+			mimReflection.addAttribute( playerAttribute );
+		}
+		config.cacheObjectClasses( mimReflection );
+		
+		// subscribed UCEF simulation control interactions
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 		
 		// hear about callbacks *immediately*, rather than when evoked, otherwise
 		// we don't know about joined federates until after the ticking starts 

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/ChallengerManager.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/ChallengerManager.java
@@ -24,12 +24,10 @@
 package gov.nist.ucef.hla.example.challenger;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
-import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
+import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.example.fedman.FedManConstants;
 import gov.nist.ucef.hla.example.fedman.FedManFederate;
 import gov.nist.ucef.hla.ucef.SimEnd;
@@ -125,23 +123,19 @@ public class ChallengerManager
 		// in MIM) to detect joining federates. Note that since this
 		// is a non-UCEF reflection, the `DataType` parameter here 
 		// does not really matter too much
-		ObjectClass mimReflection = new ObjectClass( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME, 
-		                                             Sharing.SUBSCRIBE );
+		ObjectClass mimReflection = ObjectClass.Sub( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME );
 		for( String attributeName : FedManConstants.HLAFEDERATE_ATTRIBUTE_NAMES )
 		{
-			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
-			                                                       DataType.UNKNOWN, 
-			                                                       Sharing.SUBSCRIBE );
-			mimReflection.addAttribute( playerAttribute );
+			mimReflection.addAttributeSub( attributeName, DataType.UNKNOWN);
 		}
 		config.cacheObjectClasses( mimReflection );
 		
-		// subscribed UCEF simulation control interactions
+		// The federation manager publishes certain UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
-		);
+       		InteractionClass.Pub( SimPause.interactionName() ),
+       		InteractionClass.Pub( SimResume.interactionName() ),
+       		InteractionClass.Pub( SimEnd.interactionName() )
+    	);
 		
 		// hear about callbacks *immediately*, rather than when evoked, otherwise
 		// we don't know about joined federates until after the ticking starts 

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ChallengeFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ChallengeFederate.java
@@ -31,6 +31,11 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.challenger.helpers._ChallengeFederate;
@@ -568,15 +573,30 @@ public class ChallengeFederate extends _ChallengeFederate
 		config.addFomPath( "ChallengeResponse/fom/ChallengeResponse.xml" );
 		config.addSomPath( "ChallengeResponse/som/Challenge.xml" );
 		
-		// set up lists of objects/attributes and interactions to subscribe to
-		config.addSubscribedInteraction( ResponseInteraction.interactionClassName() );
-		// set up lists of objects/attributes and interactions to publish
-		config.addPublishedAttributes( ChallengeObject.objectClassName(), ChallengeObject.attributeNames() );
-		config.addPublishedInteraction( ChallengeInteraction.interactionClassName() );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass( ResponseInteraction.interactionClassName(),  Sharing.SUBSCRIBE ),
+            new InteractionClass( ChallengeInteraction.interactionClassName(), Sharing.PUBLISH )
+		);
+
+		// set up object class reflections to publish and subscribe to
+		ObjectClass challengeReflection =
+		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.PUBLISH );
+		for( String attributeName : ChallengeObject.attributeNames() )
+		{
+			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
+			                                                       DataType.STRING, 
+			                                                       Sharing.PUBLISH );
+			challengeReflection.addAttribute( playerAttribute );
+		}
+		config.cacheObjectClasses( challengeReflection );
 		
 		// subscribed UCEF simulation control interactions
-		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                  SimEnd.interactionName() );
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 		
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ChallengeFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ChallengeFederate.java
@@ -33,9 +33,7 @@ import java.util.stream.Collectors;
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.challenger.helpers._ChallengeFederate;
@@ -575,27 +573,23 @@ public class ChallengeFederate extends _ChallengeFederate
 		
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass( ResponseInteraction.interactionClassName(),  Sharing.SUBSCRIBE ),
-            new InteractionClass( ChallengeInteraction.interactionClassName(), Sharing.PUBLISH )
+            InteractionClass.Sub( ResponseInteraction.interactionClassName() ),
+            InteractionClass.Pub( ChallengeInteraction.interactionClassName() )
 		);
 
 		// set up object class reflections to publish and subscribe to
-		ObjectClass challengeReflection =
-		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.PUBLISH );
+		ObjectClass challengeReflection = ObjectClass.Pub( ChallengeObject.objectClassName() );
 		for( String attributeName : ChallengeObject.attributeNames() )
 		{
-			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
-			                                                       DataType.STRING, 
-			                                                       Sharing.PUBLISH );
-			challengeReflection.addAttribute( playerAttribute );
+			challengeReflection.addAttributePub( attributeName, DataType.STRING );
 		}
 		config.cacheObjectClasses( challengeReflection );
 		
 		// subscribed UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+    		InteractionClass.Sub( SimPause.interactionName() ),
+    		InteractionClass.Sub( SimResume.interactionName() ),
+    		InteractionClass.Sub( SimEnd.interactionName() )
 		);
 		
 		// somebody set us up the FOM...

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ResponseFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ResponseFederate.java
@@ -1,5 +1,5 @@
 /*
- * This software is contributed as a public service by The National Institute of Standards 
+* This software is contributed as a public service by The National Institute of Standards 
  * and Technology (NIST) and is not subject to U.S. Copyright
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this 
@@ -27,6 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.challenger.helpers._ResponseFederate;
@@ -268,15 +273,30 @@ public class ResponseFederate extends _ResponseFederate
 		config.setFederateType( "ResponseFederate" );
 		config.setFederationName( "ChallengeResponseFederation" );
 
-		// set up lists of objects/attributes and interactions to subscribe to
-		config.addSubscribedAttributes( ChallengeObject.objectClassName(), ChallengeObject.attributeNames() );
-		config.addSubscribedInteraction( ChallengeInteraction.interactionClassName() );
-		// set up lists of objects/attributes and interactions to publish
-		config.addPublishedInteraction( ResponseInteraction.interactionClassName() );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass( ChallengeInteraction.interactionClassName(), Sharing.SUBSCRIBE ),
+            new InteractionClass( ResponseInteraction.interactionClassName(),  Sharing.PUBLISH )
+   		);
+		
+		// set up object class reflections to publish and subscribe to
+		ObjectClass challengeReflection =
+		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.SUBSCRIBE );
+		for( String attributeName : ChallengeObject.attributeNames() )
+		{
+			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
+			                                                       DataType.STRING, 
+			                                                       Sharing.SUBSCRIBE );
+			challengeReflection.addAttribute( playerAttribute );
+		}
+		config.cacheObjectClasses( challengeReflection );
 		
 		// subscribed UCEF simulation control interactions
-		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                  SimEnd.interactionName() );
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ResponseFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/challenger/federates/ResponseFederate.java
@@ -29,9 +29,7 @@ import java.util.List;
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.challenger.helpers._ResponseFederate;
@@ -275,27 +273,23 @@ public class ResponseFederate extends _ResponseFederate
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass( ChallengeInteraction.interactionClassName(), Sharing.SUBSCRIBE ),
-            new InteractionClass( ResponseInteraction.interactionClassName(),  Sharing.PUBLISH )
+            InteractionClass.Sub( ChallengeInteraction.interactionClassName() ),
+            InteractionClass.Pub( ResponseInteraction.interactionClassName() )
    		);
 		
 		// set up object class reflections to publish and subscribe to
-		ObjectClass challengeReflection =
-		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.SUBSCRIBE );
+		ObjectClass challengeReflection = ObjectClass.Sub( ChallengeObject.objectClassName() );
 		for( String attributeName : ChallengeObject.attributeNames() )
 		{
-			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
-			                                                       DataType.STRING, 
-			                                                       Sharing.SUBSCRIBE );
-			challengeReflection.addAttribute( playerAttribute );
+			challengeReflection.addAttributeSub( attributeName, DataType.STRING );
 		}
 		config.cacheObjectClasses( challengeReflection );
 		
 		// subscribed UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+    		InteractionClass.Sub( SimPause.interactionName() ),
+    		InteractionClass.Sub( SimResume.interactionName() ),
+    		InteractionClass.Sub( SimEnd.interactionName() )
 		);
 
 		// somebody set us up the FOM...

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/fedman/FederationManager.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/fedman/FederationManager.java
@@ -26,9 +26,7 @@ package gov.nist.ucef.hla.example.fedman;
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.ucef.SimEnd;
 import gov.nist.ucef.hla.ucef.SimPause;
@@ -122,25 +120,21 @@ public class FederationManager
 		// in MIM) to detect joining federates. Note that since this
 		// is a non-UCEF reflection, the `DataType` parameter here 
 		// does not really matter too much
-		ObjectClass mimReflection = new ObjectClass( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME, 
-		                                             Sharing.SUBSCRIBE );
+		ObjectClass mimReflection = ObjectClass.Sub( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME );
 		for( String attributeName : FedManConstants.HLAFEDERATE_ATTRIBUTE_NAMES )
 		{
-			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
-			                                                       DataType.UNKNOWN,
-			                                                       Sharing.SUBSCRIBE );
-			mimReflection.addAttribute( playerAttribute );
+			mimReflection.addAttributeSub( attributeName, DataType.UNKNOWN );
 		}
 		config.cacheObjectClasses( mimReflection );
 		
-		// subscribed UCEF simulation control interactions
+		// The federation manager publishes certain UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
-		);
+       		InteractionClass.Pub( SimPause.interactionName() ),
+       		InteractionClass.Pub( SimResume.interactionName() ),
+       		InteractionClass.Pub( SimEnd.interactionName() )
+    	);
 		
-		// here about callbacks *immediately*, rather than when evoked, otherwise
+		// hear about callbacks *immediately*, rather than when evoked, otherwise
 		// we don't know about joined federates until after the ticking starts 
 		config.setCallbacksAreEvoked( false ); // use CallbackModel.HLA_IMMEDIATE
 		

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/fedman/FederationManager.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/fedman/FederationManager.java
@@ -24,6 +24,11 @@
 package gov.nist.ucef.hla.example.fedman;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.ucef.SimEnd;
 import gov.nist.ucef.hla.ucef.SimPause;
@@ -113,12 +118,27 @@ public class FederationManager
 		// a federation manager is allowed to create a required federation
 		config.setCanCreateFederation( true );
 
-		// subscribe to reflections described in MIM to detected joining federates 
-		config.addSubscribedAttributes( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME, FedManConstants.HLAFEDERATE_ATTRIBUTE_NAMES );
+		// set up object class reflections to subscribe to (described 
+		// in MIM) to detect joining federates. Note that since this
+		// is a non-UCEF reflection, the `DataType` parameter here 
+		// does not really matter too much
+		ObjectClass mimReflection = new ObjectClass( FedManConstants.HLAFEDERATE_OBJECT_CLASS_NAME, 
+		                                             Sharing.SUBSCRIBE );
+		for( String attributeName : FedManConstants.HLAFEDERATE_ATTRIBUTE_NAMES )
+		{
+			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
+			                                                       DataType.UNKNOWN,
+			                                                       Sharing.SUBSCRIBE );
+			mimReflection.addAttribute( playerAttribute );
+		}
+		config.cacheObjectClasses( mimReflection );
 		
-		// published UCEF interactions
-		config.addPublishedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                 SimEnd.interactionName() );
+		// subscribed UCEF simulation control interactions
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 		
 		// here about callbacks *immediately*, rather than when evoked, otherwise
 		// we don't know about joined federates until after the ticking starts 

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePingFederate.java
@@ -23,9 +23,17 @@
  */
 package gov.nist.ucef.hla.example.immediate.federates;
 
+import java.util.Map.Entry;
+
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
+import gov.nist.ucef.hla.example.challenger.reflections.ChallengeObject;
 import gov.nist.ucef.hla.example.immediate.helpers._ImmediatePingFederate;
 import gov.nist.ucef.hla.example.smart.interactions.Ping;
 import gov.nist.ucef.hla.example.smart.interactions.Pong;
@@ -166,15 +174,32 @@ public class ImmediatePingFederate extends _ImmediatePingFederate
 		config.setFederateType( "PingFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of objects/attributes to be published and subscribed to
-		config.addPublishedAttributes( Player.objectClassName(), Player.attributeNames() );
-		config.addSubscribedAttributes( Player.objectClassName(), Player.attributeNames() );
-		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( Ping.interactionClassName() );
-		config.addSubscribedInteraction( Pong.interactionClassName() );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+		    new InteractionClass( Ping.interactionClassName(), Sharing.PUBLISH ),
+		    new InteractionClass( Pong.interactionClassName(), Sharing.SUBSCRIBE )
+		);
+		
+		// set up object class reflections to publish and subscribe to
+		ObjectClass playerReflection =
+		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.PUBLISHSUBSCRIBE );
+		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
+		{
+			String name = entry.getKey();
+			DataType dataType = entry.getValue();
+			ObjectAttribute playerAttribute = new ObjectAttribute( name, 
+			                                                       dataType, 
+			                                                       Sharing.PUBLISHSUBSCRIBE );
+			playerReflection.addAttribute( playerAttribute );
+		}
+		config.cacheObjectClasses( playerReflection );
+		
 		// subscribed UCEF simulation control interactions
-		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                  SimEnd.interactionName() );
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePingFederate.java
@@ -26,13 +26,11 @@ package gov.nist.ucef.hla.example.immediate.federates;
 import java.util.Map.Entry;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
-import gov.nist.ucef.hla.base.UCEFException;
-import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
+import gov.nist.ucef.hla.base.UCEFException;
+import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.challenger.reflections.ChallengeObject;
 import gov.nist.ucef.hla.example.immediate.helpers._ImmediatePingFederate;
 import gov.nist.ucef.hla.example.smart.interactions.Ping;
@@ -176,30 +174,26 @@ public class ImmediatePingFederate extends _ImmediatePingFederate
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-		    new InteractionClass( Ping.interactionClassName(), Sharing.PUBLISH ),
-		    new InteractionClass( Pong.interactionClassName(), Sharing.SUBSCRIBE )
+		    InteractionClass.Pub( Ping.interactionClassName() ),
+		    InteractionClass.Sub( Pong.interactionClassName() )
 		);
 		
 		// set up object class reflections to publish and subscribe to
-		ObjectClass playerReflection =
-		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.PUBLISHSUBSCRIBE );
+		ObjectClass playerReflection = ObjectClass.PubSub( ChallengeObject.objectClassName() );
 		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
 		{
 			String name = entry.getKey();
 			DataType dataType = entry.getValue();
-			ObjectAttribute playerAttribute = new ObjectAttribute( name, 
-			                                                       dataType, 
-			                                                       Sharing.PUBLISHSUBSCRIBE );
-			playerReflection.addAttribute( playerAttribute );
+			playerReflection.addAttributePubSub( name, dataType );
 		}
 		config.cacheObjectClasses( playerReflection );
 		
 		// subscribed UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
-		);
+       		InteractionClass.Sub( SimPause.interactionName() ),
+       		InteractionClass.Sub( SimResume.interactionName() ),
+       		InteractionClass.Sub( SimEnd.interactionName() )
+    	);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePongFederate.java
@@ -23,9 +23,17 @@
  */
 package gov.nist.ucef.hla.example.immediate.federates;
 
+import java.util.Map.Entry;
+
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
+import gov.nist.ucef.hla.example.challenger.reflections.ChallengeObject;
 import gov.nist.ucef.hla.example.immediate.helpers._ImmediatePongFederate;
 import gov.nist.ucef.hla.example.smart.interactions.Ping;
 import gov.nist.ucef.hla.example.smart.interactions.Pong;
@@ -165,15 +173,32 @@ public class ImmediatePongFederate extends _ImmediatePongFederate
 		config.setFederateType( "PongFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of objects/attributes to be published and subscribed to
-		config.addPublishedAttributes( Player.objectClassName(), Player.attributeNames() );
-		config.addSubscribedAttributes( Player.objectClassName(), Player.attributeNames() );
-		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( Pong.interactionClassName() );
-		config.addSubscribedInteraction( Ping.interactionClassName() );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass( Pong.interactionClassName(), Sharing.PUBLISH ),
+		    new InteractionClass( Ping.interactionClassName(), Sharing.SUBSCRIBE )
+		);
+		
+		// set up object class reflections to publish and subscribe to
+		ObjectClass playerReflection =
+		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.PUBLISHSUBSCRIBE );
+		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
+		{
+			String name = entry.getKey();
+			DataType dataType = entry.getValue();
+			ObjectAttribute playerAttribute = new ObjectAttribute( name, 
+			                                                       dataType, 
+			                                                       Sharing.PUBLISHSUBSCRIBE );
+			playerReflection.addAttribute( playerAttribute );
+		}
+		config.cacheObjectClasses( playerReflection );
+		
 		// subscribed UCEF simulation control interactions
-		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                  SimEnd.interactionName() );
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/immediate/federates/ImmediatePongFederate.java
@@ -26,13 +26,11 @@ package gov.nist.ucef.hla.example.immediate.federates;
 import java.util.Map.Entry;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
-import gov.nist.ucef.hla.base.UCEFException;
-import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
+import gov.nist.ucef.hla.base.UCEFException;
+import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.challenger.reflections.ChallengeObject;
 import gov.nist.ucef.hla.example.immediate.helpers._ImmediatePongFederate;
 import gov.nist.ucef.hla.example.smart.interactions.Ping;
@@ -175,30 +173,26 @@ public class ImmediatePongFederate extends _ImmediatePongFederate
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass( Pong.interactionClassName(), Sharing.PUBLISH ),
-		    new InteractionClass( Ping.interactionClassName(), Sharing.SUBSCRIBE )
+            InteractionClass.Pub( Pong.interactionClassName() ),
+		    InteractionClass.Sub( Ping.interactionClassName() )
 		);
 		
 		// set up object class reflections to publish and subscribe to
-		ObjectClass playerReflection =
-		    new ObjectClass( ChallengeObject.objectClassName(), Sharing.PUBLISHSUBSCRIBE );
+		ObjectClass playerReflection = ObjectClass.PubSub( ChallengeObject.objectClassName() );
 		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
 		{
 			String name = entry.getKey();
 			DataType dataType = entry.getValue();
-			ObjectAttribute playerAttribute = new ObjectAttribute( name, 
-			                                                       dataType, 
-			                                                       Sharing.PUBLISHSUBSCRIBE );
-			playerReflection.addAttribute( playerAttribute );
+			playerReflection.addAttributePubSub( name, dataType );
 		}
 		config.cacheObjectClasses( playerReflection );
 		
 		// subscribed UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
-		);
+       		InteractionClass.Sub( SimPause.interactionName() ),
+       		InteractionClass.Sub( SimResume.interactionName() ),
+       		InteractionClass.Sub( SimEnd.interactionName() )
+   		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPingFederate.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
+import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.ucef.NoOpFederate;
@@ -161,8 +163,11 @@ public class NoOpPingFederate extends NoOpFederate
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( PING_INTERACTION_ID );
-		config.addSubscribedInteraction( PONG_INTERACTION_ID );
+		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
+		                                                                    Sharing.PUBLISH);
+		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
+		                                                                    Sharing.SUBSCRIBE);
+		config.addInteractions( pingInteraction, pongInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPingFederate.java
@@ -162,12 +162,11 @@ public class NoOpPingFederate extends NoOpFederate
 		config.setFederateType( "PingFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of interactions to be published and subscribed to
-		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
-		                                                                    Sharing.PUBLISH);
-		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
-		                                                                    Sharing.SUBSCRIBE);
-		config.addInteractions( pingInteraction, pongInteraction );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new Types.InteractionClass( PING_INTERACTION_ID, Sharing.PUBLISH ),
+            new Types.InteractionClass( PONG_INTERACTION_ID, Sharing.SUBSCRIBE )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPongFederate.java
@@ -162,12 +162,11 @@ public class NoOpPongFederate extends NoOpFederate
 		config.setFederateType( "PongFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of interactions to be published and subscribed to
-		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
-		                                                                    Sharing.PUBLISH);
-		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
-		                                                                    Sharing.SUBSCRIBE);
-		config.addInteractions( pongInteraction, pingInteraction );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+	        new Types.InteractionClass( PONG_INTERACTION_ID, Sharing.PUBLISH ),
+		    new Types.InteractionClass( PING_INTERACTION_ID, Sharing.SUBSCRIBE )
+		);
 		
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/noopbase/NoOpPongFederate.java
@@ -29,8 +29,10 @@ import java.util.Map;
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
+import gov.nist.ucef.hla.base.Types;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.ucef.NoOpFederate;
 import gov.nist.ucef.hla.util.Constants;
 import gov.nist.ucef.hla.util.FileUtils;
@@ -161,9 +163,12 @@ public class NoOpPongFederate extends NoOpFederate
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( PONG_INTERACTION_ID );
-		config.addSubscribedInteraction( PING_INTERACTION_ID );
-
+		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID,
+		                                                                    Sharing.PUBLISH);
+		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
+		                                                                    Sharing.SUBSCRIBE);
+		config.addInteractions( pongInteraction, pingInteraction );
+		
 		// somebody set us up the FOM...
 		try
 		{

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
@@ -23,7 +23,14 @@
  */
 package gov.nist.ucef.hla.example.smart.federates;
 
+import java.util.Map.Entry;
+
 import gov.nist.ucef.hla.base.FederateConfiguration;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.smart.helpers._SmartPingFederate;
@@ -166,14 +173,34 @@ public class SmartPingFederate extends _SmartPingFederate
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of objects/attributes to be published and subscribed to
-		config.addPublishedAttributes( Player.objectClassName(), Player.attributeNames() );
-		config.addSubscribedAttributes( Player.objectClassName(), Player.attributeNames() );
+		ObjectClass playerReflection = new ObjectClass( Player.objectClassName(), 
+		                                                Sharing.PUBLISHSUBSCRIBE );
+		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
+		{
+			String attributeName = entry.getKey();
+			DataType attributeType = entry.getValue();
+			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
+			                                                       attributeType, 
+			                                                       Sharing.PUBLISHSUBSCRIBE );
+			playerReflection.addAttribute( playerAttribute );
+		}
+		config.addReflection( playerReflection );
+		
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( Ping.interactionClassName() );
-		config.addSubscribedInteraction( Pong.interactionClassName() );
+		InteractionClass pingInteraction = new InteractionClass( Ping.interactionClassName(),
+		                                                         Sharing.PUBLISH );
+		InteractionClass pongInteraction = new InteractionClass( Pong.interactionClassName(), 
+		                                                         Sharing.SUBSCRIBE );
+		config.addInteractions( pingInteraction, pongInteraction );
+
 		// subscribed UCEF simulation control interactions
-		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                  SimEnd.interactionName() );
+		InteractionClass simPauseInteraction = new InteractionClass( SimPause.interactionName(), 
+		                                                             Sharing.SUBSCRIBE );
+		InteractionClass simResumeInteraction = new InteractionClass( SimResume.interactionName(), 
+		                                                              Sharing.SUBSCRIBE );
+		InteractionClass simEndInteraction = new InteractionClass( SimEnd.interactionName(), 
+		                                                           Sharing.SUBSCRIBE );
+		config.addInteractions( simPauseInteraction, simResumeInteraction, simEndInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
@@ -28,9 +28,7 @@ import java.util.Map.Entry;
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.smart.helpers._SmartPingFederate;
@@ -174,30 +172,26 @@ public class SmartPingFederate extends _SmartPingFederate
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass( Ping.interactionClassName(), Sharing.PUBLISH ),
-            new InteractionClass( Pong.interactionClassName(), Sharing.SUBSCRIBE )
+            InteractionClass.Pub( Ping.interactionClassName() ),
+            InteractionClass.Sub( Pong.interactionClassName() )
         );
 		
 		// set up object class reflections to publish and subscribe to
-		ObjectClass playerReflection = new ObjectClass( Player.objectClassName(), 
-		                                                Sharing.PUBLISHSUBSCRIBE );
+		ObjectClass playerReflection = ObjectClass.PubSub( Player.objectClassName() );
 		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
 		{
 			String attributeName = entry.getKey();
 			DataType attributeType = entry.getValue();
-			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
-			                                                       attributeType, 
-			                                                       Sharing.PUBLISHSUBSCRIBE );
-			playerReflection.addAttribute( playerAttribute );
+			playerReflection.addAttributePubSub( attributeName, attributeType );
 		}
 		config.cacheObjectClasses( playerReflection );
 		
 		// subscribed UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
-		);
+       		InteractionClass.Sub( SimPause.interactionName() ),
+       		InteractionClass.Sub( SimResume.interactionName() ),
+       		InteractionClass.Sub( SimEnd.interactionName() )
+   		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPingFederate.java
@@ -172,7 +172,13 @@ public class SmartPingFederate extends _SmartPingFederate
 		config.setFederateType( "PingFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of objects/attributes to be published and subscribed to
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass( Ping.interactionClassName(), Sharing.PUBLISH ),
+            new InteractionClass( Pong.interactionClassName(), Sharing.SUBSCRIBE )
+        );
+		
+		// set up object class reflections to publish and subscribe to
 		ObjectClass playerReflection = new ObjectClass( Player.objectClassName(), 
 		                                                Sharing.PUBLISHSUBSCRIBE );
 		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
@@ -184,23 +190,14 @@ public class SmartPingFederate extends _SmartPingFederate
 			                                                       Sharing.PUBLISHSUBSCRIBE );
 			playerReflection.addAttribute( playerAttribute );
 		}
-		config.addReflection( playerReflection );
+		config.cacheObjectClasses( playerReflection );
 		
-		// set up lists of interactions to be published and subscribed to
-		InteractionClass pingInteraction = new InteractionClass( Ping.interactionClassName(),
-		                                                         Sharing.PUBLISH );
-		InteractionClass pongInteraction = new InteractionClass( Pong.interactionClassName(), 
-		                                                         Sharing.SUBSCRIBE );
-		config.addInteractions( pingInteraction, pongInteraction );
-
 		// subscribed UCEF simulation control interactions
-		InteractionClass simPauseInteraction = new InteractionClass( SimPause.interactionName(), 
-		                                                             Sharing.SUBSCRIBE );
-		InteractionClass simResumeInteraction = new InteractionClass( SimResume.interactionName(), 
-		                                                              Sharing.SUBSCRIBE );
-		InteractionClass simEndInteraction = new InteractionClass( SimEnd.interactionName(), 
-		                                                           Sharing.SUBSCRIBE );
-		config.addInteractions( simPauseInteraction, simResumeInteraction, simEndInteraction );
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
@@ -171,7 +171,13 @@ public class SmartPongFederate extends _SmartPongFederate
 		config.setFederateType( "PongFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of objects/attributes to be published and subscribed to
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass( Pong.interactionClassName(), Sharing.PUBLISH ),
+            new InteractionClass( Ping.interactionClassName(), Sharing.SUBSCRIBE )
+        );
+		
+		// set up object class reflections to publish and subscribe to
 		ObjectClass playerReflection = new ObjectClass( Player.objectClassName(), 
 		                                                Sharing.PUBLISHSUBSCRIBE );
 		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
@@ -183,24 +189,14 @@ public class SmartPongFederate extends _SmartPongFederate
 			                                                       Sharing.PUBLISHSUBSCRIBE );
 			playerReflection.addAttribute( playerAttribute );
 		}
-		config.addReflection( playerReflection );
+		config.cacheObjectClasses( playerReflection );
 
-		// set up lists of interactions to be published and subscribed to
-		// set up lists of interactions to be published and subscribed to
-		InteractionClass pongInteraction = new InteractionClass( Pong.interactionClassName(), 
-		                                                         Sharing.PUBLISH );
-		InteractionClass pingInteraction = new InteractionClass( Ping.interactionClassName(),
-		                                                         Sharing.SUBSCRIBE );
-		config.addInteractions( pingInteraction, pongInteraction );
-		
 		// subscribed UCEF simulation control interactions
-		InteractionClass simPauseInteraction = new InteractionClass( SimPause.interactionName(), 
-		                                                             Sharing.SUBSCRIBE );
-		InteractionClass simResumeInteraction = new InteractionClass( SimResume.interactionName(), 
-		                                                              Sharing.SUBSCRIBE );
-		InteractionClass simEndInteraction = new InteractionClass( SimEnd.interactionName(), 
-		                                                           Sharing.SUBSCRIBE );
-		config.addInteractions( simPauseInteraction, simResumeInteraction, simEndInteraction );
+		config.cacheInteractionClasses( 
+    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
+    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
@@ -26,13 +26,11 @@ package gov.nist.ucef.hla.example.smart.federates;
 import java.util.Map.Entry;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
-import gov.nist.ucef.hla.base.UCEFException;
-import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.base.Types.DataType;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.ObjectAttribute;
 import gov.nist.ucef.hla.base.Types.ObjectClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
+import gov.nist.ucef.hla.base.UCEFException;
+import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.example.smart.helpers._SmartPongFederate;
 import gov.nist.ucef.hla.example.smart.interactions.Ping;
 import gov.nist.ucef.hla.example.smart.interactions.Pong;
@@ -173,30 +171,26 @@ public class SmartPongFederate extends _SmartPongFederate
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass( Pong.interactionClassName(), Sharing.PUBLISH ),
-            new InteractionClass( Ping.interactionClassName(), Sharing.SUBSCRIBE )
+            InteractionClass.Pub( Pong.interactionClassName() ),
+            InteractionClass.Sub( Ping.interactionClassName() )
         );
 		
 		// set up object class reflections to publish and subscribe to
-		ObjectClass playerReflection = new ObjectClass( Player.objectClassName(), 
-		                                                Sharing.PUBLISHSUBSCRIBE );
+		ObjectClass playerReflection = ObjectClass.PubSub( Player.objectClassName() );
 		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
 		{
 			String attributeName = entry.getKey();
 			DataType attributeType = entry.getValue();
-			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
-			                                                       attributeType, 
-			                                                       Sharing.PUBLISHSUBSCRIBE );
-			playerReflection.addAttribute( playerAttribute );
+			playerReflection.addAttributePubSub( attributeName, attributeType );
 		}
 		config.cacheObjectClasses( playerReflection );
 
 		// subscribed UCEF simulation control interactions
 		config.cacheInteractionClasses( 
-    		new InteractionClass( SimPause.interactionName(),  Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimResume.interactionName(), Sharing.SUBSCRIBE ),
-    		new InteractionClass( SimEnd.interactionName(),    Sharing.SUBSCRIBE )
-		);
+       		InteractionClass.Sub( SimPause.interactionName() ),
+       		InteractionClass.Sub( SimResume.interactionName() ),
+       		InteractionClass.Sub( SimEnd.interactionName() )
+   		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/federates/SmartPongFederate.java
@@ -23,9 +23,16 @@
  */
 package gov.nist.ucef.hla.example.smart.federates;
 
+import java.util.Map.Entry;
+
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.base.Types.DataType;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.ObjectAttribute;
+import gov.nist.ucef.hla.base.Types.ObjectClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.example.smart.helpers._SmartPongFederate;
 import gov.nist.ucef.hla.example.smart.interactions.Ping;
 import gov.nist.ucef.hla.example.smart.interactions.Pong;
@@ -165,14 +172,35 @@ public class SmartPongFederate extends _SmartPongFederate
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of objects/attributes to be published and subscribed to
-		config.addPublishedAttributes( Player.objectClassName(), Player.attributeNames() );
-		config.addSubscribedAttributes( Player.objectClassName(), Player.attributeNames() );
+		ObjectClass playerReflection = new ObjectClass( Player.objectClassName(), 
+		                                                Sharing.PUBLISHSUBSCRIBE );
+		for( Entry<String,DataType> entry : Player.attributes().entrySet() )
+		{
+			String attributeName = entry.getKey();
+			DataType attributeType = entry.getValue();
+			ObjectAttribute playerAttribute = new ObjectAttribute( attributeName, 
+			                                                       attributeType, 
+			                                                       Sharing.PUBLISHSUBSCRIBE );
+			playerReflection.addAttribute( playerAttribute );
+		}
+		config.addReflection( playerReflection );
+
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( Pong.interactionClassName() );
-		config.addSubscribedInteraction( Ping.interactionClassName() );
+		// set up lists of interactions to be published and subscribed to
+		InteractionClass pongInteraction = new InteractionClass( Pong.interactionClassName(), 
+		                                                         Sharing.PUBLISH );
+		InteractionClass pingInteraction = new InteractionClass( Ping.interactionClassName(),
+		                                                         Sharing.SUBSCRIBE );
+		config.addInteractions( pingInteraction, pongInteraction );
+		
 		// subscribed UCEF simulation control interactions
-		config.addSubscribedInteractions( SimPause.interactionName(), SimResume.interactionName(),
-		                                  SimEnd.interactionName() );
+		InteractionClass simPauseInteraction = new InteractionClass( SimPause.interactionName(), 
+		                                                             Sharing.SUBSCRIBE );
+		InteractionClass simResumeInteraction = new InteractionClass( SimResume.interactionName(), 
+		                                                              Sharing.SUBSCRIBE );
+		InteractionClass simEndInteraction = new InteractionClass( SimEnd.interactionName(), 
+		                                                           Sharing.SUBSCRIBE );
+		config.addInteractions( simPauseInteraction, simResumeInteraction, simEndInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/interactions/Ping.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/interactions/Ping.java
@@ -23,8 +23,13 @@
  */
 package gov.nist.ucef.hla.example.smart.interactions;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.RTIAmbassadorWrapper;
+import gov.nist.ucef.hla.base.Types.DataType;
 
 public class Ping extends HLAInteraction
 {
@@ -37,6 +42,13 @@ public class Ping extends HLAInteraction
 	
 	// interaction parameters and types
 	private static final String PARAM_KEY_COUNT = "count";
+	private static final DataType PARAM_TYPE_COUNT = DataType.INT;
+	
+	// a map for finding a data type for an attribute name - this is to provide
+	// quick lookups and avoid iterating over all attributes
+	private static final Map<String,DataType> PARAMETERS_LOOKUP =
+		Collections.unmodifiableMap( initializeMapping() );
+	
 	
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -97,5 +109,28 @@ public class Ping extends HLAInteraction
 	public static String interactionClassName()
 	{
 		return INTERACTION_NAME;
+	}
+	
+	/**
+	 * Obtain the parameters associated with this kind of interaction
+	 * 
+	 * @return a map associating the String names of the parameters and their data types
+	 */
+	public static Map<String, DataType> parameters()
+	{
+		return PARAMETERS_LOOKUP;
+	}
+	
+	/**
+	 * Private initializer method for the parameter-datatype lookup map
+	 * 
+	 * @return a lookup map which pairs parameter names and the corresponding
+	 *         {@link DataType}s
+	 */
+	private static Map<String,DataType> initializeMapping()
+	{
+		Map<String,DataType> lookupMap = new HashMap<String,DataType>();
+		lookupMap.put( PARAM_KEY_COUNT, PARAM_TYPE_COUNT );
+		return lookupMap;
 	}
 }

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/interactions/Pong.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/interactions/Pong.java
@@ -23,8 +23,13 @@
  */
 package gov.nist.ucef.hla.example.smart.interactions;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.RTIAmbassadorWrapper;
+import gov.nist.ucef.hla.base.Types.DataType;
 
 public class Pong extends HLAInteraction
 {
@@ -37,6 +42,12 @@ public class Pong extends HLAInteraction
 	
 	// interaction parameters and types
 	private static final String PARAM_KEY_LETTER = "letter";
+	private static final DataType PARAM_TYPE_LETTER = DataType.STRING;
+	
+	// a map for finding a data type for an attribute name - this is to provide
+	// quick lookups and avoid iterating over all attributes
+	private static final Map<String,DataType> PARAMETERS_LOOKUP =
+		Collections.unmodifiableMap( initializeMapping() );
 	
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -98,4 +109,27 @@ public class Pong extends HLAInteraction
 	{
 		return INTERACTION_NAME;
 	}
+	
+	/**
+	 * Obtain the parameters associated with this kind of interaction
+	 * 
+	 * @return a map associating the String names of the parameters and their data types
+	 */
+	public static Map<String, DataType> parameters()
+	{
+		return PARAMETERS_LOOKUP;
+	}
+	
+	/**
+	 * Private initializer method for the parameter-datatype lookup map
+	 * 
+	 * @return a lookup map which pairs parameter names and the corresponding
+	 *         {@link DataType}s
+	 */
+	private static Map<String,DataType> initializeMapping()
+	{
+		Map<String,DataType> lookupMap = new HashMap<String,DataType>();
+		lookupMap.put( PARAM_KEY_LETTER, PARAM_TYPE_LETTER );
+		return lookupMap;
+	}	
 }

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/smart/reflections/Player.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/smart/reflections/Player.java
@@ -23,8 +23,13 @@
  */
 package gov.nist.ucef.hla.example.smart.reflections;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import gov.nist.ucef.hla.base.HLAObject;
 import gov.nist.ucef.hla.base.RTIAmbassadorWrapper;
+import gov.nist.ucef.hla.base.Types.DataType;
 
 public class Player extends HLAObject
 {
@@ -32,13 +37,17 @@ public class Player extends HLAObject
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
 	// HLA identifier of this type of object - must match FOM definition
-	private static final String HLA_OBJECT_ROOT = "HLAobjectRoot.";
+	private static final String HLA_OBJECT_ROOT   = "HLAobjectRoot.";
 	private static final String OBJECT_CLASS_NAME = HLA_OBJECT_ROOT+"Player";
 	
 	// object attributes and types
-	private static final String ATTRIBUTE_KEY_NAME = "name";
+	private static final String ATTRIBUTE_KEY_NAME    = "name";
+	private static final DataType ATTRIBUTE_TYPE_NAME = DataType.STRING;
 	
-	private static final String[] ATTRIBUTE_NAMES = { ATTRIBUTE_KEY_NAME };
+	// a map for finding a data type for an attribute name - this is to provide
+	// quick lookups and avoid iterating over all attributes
+	private static final Map<String,DataType> ATTRIBUTES_LOOKUP =
+		Collections.unmodifiableMap( initializeMapping() );
 	
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -87,7 +96,7 @@ public class Player extends HLAObject
 	{
 		return getAsString( ATTRIBUTE_KEY_NAME );
 	}
-
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------
@@ -102,12 +111,25 @@ public class Player extends HLAObject
 	}
 	
 	/**
-	 * Obtain the HLA object class name identifying this type of object
+	 * Obtain the attributes associated with this kind of reflection
 	 * 
-	 * @return the HLA object class name identifying this type of object
+	 * @return a map associating the String names of the attributes and their data types
 	 */
-	public static String[] attributeNames()
+	public static Map<String,DataType> attributes()
 	{
-		return ATTRIBUTE_NAMES;
+		return ATTRIBUTES_LOOKUP;
+	}
+	
+	/**
+	 * Private initializer method for the attribute-datatype lookup map
+	 * 
+	 * @return a lookup map which pairs attribute names and the corresponding
+	 *         {@link DataType}s
+	 */
+	private static Map<String,DataType> initializeMapping()
+	{
+		Map<String,DataType> lookupMap = new HashMap<String,DataType>();
+		lookupMap.put( ATTRIBUTE_KEY_NAME, ATTRIBUTE_TYPE_NAME );
+		return lookupMap;
 	}
 }

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
@@ -31,7 +31,6 @@ import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.ucef.FederateJoin;
@@ -280,9 +279,9 @@ public class UCEFPingFederate extends UCEFFederateBase
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-            new InteractionClass(PING_INTERACTION_NAME, Sharing.PUBLISH),
-            new InteractionClass(PONG_INTERACTION_NAME, Sharing.SUBSCRIBE)
-        );
+            InteractionClass.Pub( PING_INTERACTION_NAME ),
+            InteractionClass.Sub( PONG_INTERACTION_NAME )
+		);
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
@@ -30,10 +30,10 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
-import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.ucef.FederateJoin;
 import gov.nist.ucef.hla.ucef.SimEnd;
 import gov.nist.ucef.hla.ucef.SimPause;
@@ -278,12 +278,11 @@ public class UCEFPingFederate extends UCEFFederateBase
 		 config.setFederateType( "PingFederate" );
 		 config.setFederationName( "PingPongFederation" );
 
-		// set up lists of interactions to be published and subscribed to
-		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_NAME,
-		                                                                    Sharing.PUBLISH);
-		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_NAME,
-		                                                                    Sharing.SUBSCRIBE);
-		config.addInteractions( pingInteraction, pongInteraction );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+            new InteractionClass(PING_INTERACTION_NAME, Sharing.PUBLISH),
+            new InteractionClass(PONG_INTERACTION_NAME, Sharing.SUBSCRIBE)
+        );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPingFederate.java
@@ -30,8 +30,10 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
+import gov.nist.ucef.hla.base.Types;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.ucef.FederateJoin;
 import gov.nist.ucef.hla.ucef.SimEnd;
 import gov.nist.ucef.hla.ucef.SimPause;
@@ -277,8 +279,11 @@ public class UCEFPingFederate extends UCEFFederateBase
 		 config.setFederationName( "PingPongFederation" );
 
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( PING_INTERACTION_NAME );
-		config.addSubscribedInteraction( PONG_INTERACTION_NAME );
+		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_NAME,
+		                                                                    Sharing.PUBLISH);
+		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_NAME,
+		                                                                    Sharing.SUBSCRIBE);
+		config.addInteractions( pingInteraction, pongInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
@@ -30,7 +30,7 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
-import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.InteractionClass;
 import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
@@ -278,12 +278,11 @@ public class UCEFPongFederate extends UCEFFederateBase
 		config.setFederateType( "PongFederate" );
 		config.setFederationName( "PingPongFederation" );
 
-		// set up lists of interactions to be published and subscribed to
-		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID, 
-		                                                                    Sharing.PUBLISH);
-		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
-		                                                                    Sharing.SUBSCRIBE);
-		config.addInteractions( pongInteraction, pingInteraction );
+		// set up interactions to publish and subscribe to
+		config.cacheInteractionClasses(
+   		    new InteractionClass( PONG_INTERACTION_ID, Sharing.PUBLISH ),
+		    new InteractionClass( PING_INTERACTION_ID, Sharing.SUBSCRIBE )
+        );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
@@ -30,6 +30,8 @@ import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
+import gov.nist.ucef.hla.base.Types;
+import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.ucef.FederateJoin;
@@ -143,7 +145,7 @@ public class UCEFPongFederate extends UCEFFederateBase
 	public void receiveInteraction( HLAInteraction hlaInteraction )
 	{
 		String interactionClassName = hlaInteraction.getInteractionClassName();
-		if( PING_INTERACTION_NAME.equals( interactionClassName ) )
+		if( PING_INTERACTION_ID.equals( interactionClassName ) )
 		{
 			// Ping interaction received
 			if( hlaInteraction.isPresent( PING_PARAM_COUNT ) )
@@ -253,16 +255,16 @@ public class UCEFPongFederate extends UCEFFederateBase
 		Map<String,byte[]> parameters = new HashMap<>();
 		parameters.put( PONG_PARAM_LETTER, 
 		                HLACodecUtils.encode( encoder, letter ) );
-		return makeInteraction( PONG_INTERACTION_NAME, parameters );
+		return makeInteraction( PONG_INTERACTION_ID, parameters );
 	}
 
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
 	private static final String INTERACTION_ROOT = "HLAinteractionRoot.";
-	private static final String PING_INTERACTION_NAME = INTERACTION_ROOT+"Ping";
+	private static final String PING_INTERACTION_ID = INTERACTION_ROOT+"Ping";
 	private static final String PING_PARAM_COUNT = "count";
-	private static final String PONG_INTERACTION_NAME = INTERACTION_ROOT+"Pong";
+	private static final String PONG_INTERACTION_ID = INTERACTION_ROOT+"Pong";
 	private static final String PONG_PARAM_LETTER = "letter";
 	
 	/**
@@ -277,8 +279,11 @@ public class UCEFPongFederate extends UCEFFederateBase
 		config.setFederationName( "PingPongFederation" );
 
 		// set up lists of interactions to be published and subscribed to
-		config.addPublishedInteraction( PONG_INTERACTION_NAME );
-		config.addSubscribedInteraction( PING_INTERACTION_NAME );
+		Types.InteractionClass pongInteraction = new Types.InteractionClass(PONG_INTERACTION_ID, 
+		                                                                    Sharing.PUBLISH);
+		Types.InteractionClass pingInteraction = new Types.InteractionClass(PING_INTERACTION_ID,
+		                                                                    Sharing.SUBSCRIBE);
+		config.addInteractions( pongInteraction, pingInteraction );
 
 		// somebody set us up the FOM...
 		try

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/ucef/UCEFPongFederate.java
@@ -31,7 +31,6 @@ import gov.nist.ucef.hla.base.HLACodecUtils;
 import gov.nist.ucef.hla.base.HLAInteraction;
 import gov.nist.ucef.hla.base.HLAObject;
 import gov.nist.ucef.hla.base.Types.InteractionClass;
-import gov.nist.ucef.hla.base.Types.Sharing;
 import gov.nist.ucef.hla.base.UCEFException;
 import gov.nist.ucef.hla.base.UCEFSyncPoint;
 import gov.nist.ucef.hla.ucef.FederateJoin;
@@ -280,8 +279,8 @@ public class UCEFPongFederate extends UCEFFederateBase
 
 		// set up interactions to publish and subscribe to
 		config.cacheInteractionClasses(
-   		    new InteractionClass( PONG_INTERACTION_ID, Sharing.PUBLISH ),
-		    new InteractionClass( PING_INTERACTION_ID, Sharing.SUBSCRIBE )
+   		    InteractionClass.Pub( PONG_INTERACTION_ID ),
+		    InteractionClass.Sub( PING_INTERACTION_ID )
         );
 
 		// somebody set us up the FOM...


### PR DESCRIPTION
Overall this is just a set of enhancements which together allow access to configuration information that was already there _internally_ but not queryable in a general sense.

In a more concrete sense, this is useful to developers because it allows the querying of the names of published/subscribed interactions and object classes, and also the names and data types of their associated parameters and attributes from the federate configuration.

This will become more relevant when federate configurations are read in from a SOM XML definition (via the `SOMParser`) rather than being set up programmatically as has mostly been the case so far in development. The thinking here is basically that definitions read in from a SOM are less under the control of the developer, and so could conceivably need to be queried at runtime to extract useful information on how to extract and handle information on incoming interactions and object class reflections.

In addition to this...

- utility methods were added to support simplified creation of published/subscribed interactions and object classes (and their associated attributes/parameters) when programmatically setting up a federate configuration; apart from anything else this just really neatens up the associated code and makes it much simpler for a human to parse (IMHO)
- unit testing has been updated to cover the most recent modifications
- updated comments in many places
