### PR TITLE
JSON Configuration for Federates

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -27,6 +27,11 @@
       	<version>1.1.1</version>
     </dependency>
 	<dependency>
+	    <groupId>com.googlecode.json-simple</groupId>
+	    <artifactId>json-simple</artifactId>
+	    <version>1.1.1</version>
+	</dependency>
+	<dependency>
 	    <groupId>org.portico</groupId>
 	    <artifactId>portico</artifactId>
 	    <version>2.2.0</version>

--- a/src/java/src/main/java/gov/nist/ucef/hla/base/FederateConfiguration.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/base/FederateConfiguration.java
@@ -181,6 +181,22 @@ public class FederateConfiguration
 	 * Configuration items not mentioned in the JSON structure will not have their values changed
 	 * (i.e., they will be left in their existing state).
 	 * 
+	 * Currently recognized configuration items are:
+	 * 
+	 * {
+	 *     "federateName":         STRING,
+	 *     "federateType":         STRING,
+	 *     "federationExecName":   STRING,
+	 *     "canCreateFederation":  BOOL,
+	 *     "maxJoinAttempts":      INT,
+	 *     "joinRetryIntervalSec": INT,
+	 *     "syncBeforeResign":     BOOL,
+	 *     "isTimeStepped":        BOOL,
+	 *     "callbacksAreEvoked":   BOOL,
+	 *     "lookAhead":            DOUBLE,
+	 *     "stepSize":             DOUBLE
+	 * }
+	 *   
 	 * @param config the file containing the JSON configuration data
 	 */
 	public void fromJSON(File config)
@@ -211,6 +227,22 @@ public class FederateConfiguration
 	 * Configuration items not mentioned in the JSON structure will not have their values changed
 	 * (i.e., they will be left in their existing state).
 	 *
+	 * Currently recognized configuration items are:
+	 * 
+	 * {
+	 *     "federateName":         STRING,
+	 *     "federateType":         STRING,
+	 *     "federationExecName":   STRING,
+	 *     "canCreateFederation":  BOOL,
+	 *     "maxJoinAttempts":      INT,
+	 *     "joinRetryIntervalSec": INT,
+	 *     "syncBeforeResign":     BOOL,
+	 *     "isTimeStepped":        BOOL,
+	 *     "callbacksAreEvoked":   BOOL,
+	 *     "lookAhead":            DOUBLE,
+	 *     "stepSize":             DOUBLE
+	 * }
+	 * 
 	 * @param config the {@link String} containing the JSON configuration data
 	 */
 	public void fromJSON(String config)

--- a/src/java/src/main/java/gov/nist/ucef/hla/example/fedman/FederationManager.java
+++ b/src/java/src/main/java/gov/nist/ucef/hla/example/fedman/FederationManager.java
@@ -111,6 +111,9 @@ public class FederationManager
 	 */
 	private static void initializeConfig( FederateConfiguration config )
 	{
+		System.out.println(">>>>>>>>>>>>>> BANANANSSS");
+		config.fromJSON( "{\"maxJoinasAttempts\":1.23}" );
+		
 		config.setFederateName( FedManConstants.FEDMAN_FEDERATE_NAME );
 		config.setFederateType( FedManConstants.FEDMAN_FEDERATE_TYPE );
 		config.setFederationName( "ManagedFederation" );
@@ -118,6 +121,8 @@ public class FederationManager
 		// a federation manager is allowed to create a required federation
 		config.setCanCreateFederation( true );
 
+		
+		
 		// set up object class reflections to subscribe to (described 
 		// in MIM) to detect joining federates. Note that since this
 		// is a non-UCEF reflection, the `DataType` parameter here 
@@ -150,6 +155,7 @@ public class FederationManager
 			String[] moduleFoms = { fomRootPath + "FederationManager.xml",
 			                        fomRootPath + "SmartPingPong.xml" };
 			config.addModules( FileUtils.urlsFromPaths(moduleFoms) );
+			
 			
 			// join modules
 			String[] joinModuleFoms = {};


### PR DESCRIPTION
Added the ability to configure a federate with JSON based configuration from a file containing JSON data or a JSON formatted string.

Currently recognized configuration items are:
```javascript
{
    "federateName":         STRING,
    "federateType":         STRING,
    "federationExecName":   STRING,
    "canCreateFederation":  BOOL,
    "maxJoinAttempts":      INT,
    "joinRetryIntervalSec": INT,
    "syncBeforeResign":     BOOL,
    "isTimeStepped":        BOOL,
    "callbacksAreEvoked":   BOOL,
    "lookAhead":            DOUBLE,
    "stepSize":             DOUBLE
}
```
