### PR TITLE
Federate Manager/Federates "Start" Polling

### DIFF
--- a/src/java/.gitignore
+++ b/src/java/.gitignore
@@ -1,6 +1,7 @@
 /target/
 /logs/
-/bin/
+**/bin/
 .settings
 **/*.log
 **/*.classpath
+**/*.factorypath

--- a/src/java/ucef-java-examples/pom.xml
+++ b/src/java/ucef-java-examples/pom.xml
@@ -27,11 +27,6 @@
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>gov.nist.ucef.java.tools</groupId>
-			<artifactId>ucef-java-tools</artifactId>
-			<version>ucef-java-tools-0.0.1-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.4</version>

--- a/src/java/ucef-java-genx-ping/run-ping-federate.bat
+++ b/src/java/ucef-java-genx-ping/run-ping-federate.bat
@@ -1,16 +1,37 @@
 @ECHO OFF
 
+set JAVA_MAIN_CLASS="gov.nist.hla.genx.GenxPingFederate"
+
 set MVN=
 for /f "delims=" %%i in ('where.exe mvn') do @set MVN="%%i"
-call :DequotedEcho %MVN%
-
 IF %MVN% == "" (
     call :DequotedEcho "The `mvn` (Maven) application could not be found. Ensure it is installed and placed in your PATH."
     EXIT /B
 ) ELSE (
-    %MVN% exec:java -Dexec.mainClass="gov.nist.hla.genx.GenxPingFederate" -Dexec.args="%*"
+    call :WaitForFederationManager
+    %MVN% exec:java -Dexec.mainClass="%JAVA_MAIN_CLASS%" -Dexec.args="%*"
 )
 goto :eof
+
+:WaitForFederationManager
+    setlocal enabledelayedexpansion
+    REM 'ping' the HTTP server on the federation manager  
+    REM to determine when it's a good time to start  
+    set CURL_RESPONSE=""
+    for /f "delims=" %%i in ('curl -s http://localhost:8080/query/is-waiting-for-federates') do @set CURL_RESPONSE="%%i"
+    if %CURL_RESPONSE% == "true" (
+        REM ready to go
+        EXIT /B
+    )
+    call :DequotedEcho "The Federation Manager does not seem to be ready yet..."
+    TIMEOUT /t 5 /NOBREAK
+    if ERRORLEVEL 1 (
+        REM if the user presses CTRL+C we want to exit completely
+        EXIT /B
+        goto :eof
+    )
+    REM keep looping
+    goto :WaitForFederationManager
 
 :DequotedEcho
     setlocal

--- a/src/java/ucef-java-genx-pong/run-pong-federate.bat
+++ b/src/java/ucef-java-genx-pong/run-pong-federate.bat
@@ -1,16 +1,37 @@
 @ECHO OFF
 
+set JAVA_MAIN_CLASS="gov.nist.hla.genx.GenxPongFederate"
+
 set MVN=
 for /f "delims=" %%i in ('where.exe mvn') do @set MVN="%%i"
-call :DequotedEcho %MVN%
-
 IF %MVN% == "" (
     call :DequotedEcho "The `mvn` (Maven) application could not be found. Ensure it is installed and placed in your PATH."
     EXIT /B
 ) ELSE (
-    %MVN% exec:java -Dexec.mainClass="gov.nist.hla.genx.GenxPongFederate" -Dexec.args="%*"
+    call :WaitForFederationManager
+    %MVN% exec:java -Dexec.mainClass="%JAVA_MAIN_CLASS%" -Dexec.args="%*"
 )
 goto :eof
+
+:WaitForFederationManager
+    setlocal enabledelayedexpansion
+    REM 'ping' the HTTP server on the federation manager  
+    REM to determine when it's a good time to start  
+    set CURL_RESPONSE=""
+    for /f "delims=" %%i in ('curl -s http://localhost:8080/query/is-waiting-for-federates') do @set CURL_RESPONSE="%%i"
+    if %CURL_RESPONSE% == "true" (
+        REM ready to go
+        EXIT /B
+    )
+    call :DequotedEcho "The Federation Manager does not seem to be ready yet..."
+    TIMEOUT /t 5 /NOBREAK
+    if ERRORLEVEL 1 (
+        REM if the user presses CTRL+C we want to exit completely
+        EXIT /B
+        goto :eof
+    )
+    REM keep looping
+    goto :WaitForFederationManager
 
 :DequotedEcho
     setlocal

--- a/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManFederate.java
+++ b/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManFederate.java
@@ -85,6 +85,8 @@ public class FedManFederate extends NoOpFederate
 	private long nextTimeAdvance;
 	private double maxTime;
 
+	private boolean isWaitingForFederates;
+
 	private final Object mutex_lock = new Object();
 
 	volatile boolean simShouldStart = false;
@@ -111,6 +113,7 @@ public class FedManFederate extends NoOpFederate
 		this.logicalSecond = LOGICAL_SECOND_DEFAULT;
 		this.realTimeMultiplier = REAL_TIME_MULTIPLIER_DEFAULT;
 		this.wallClockStepDelay = (long)(ONE_SECOND / this.realTimeMultiplier);
+		this.isWaitingForFederates = false;
 
 		this.nextTimeAdvance = -1;
 	}
@@ -166,6 +169,11 @@ public class FedManFederate extends NoOpFederate
 	public FedManStartRequirements getStartRequirements()
 	{
 		return this.startRequirements;
+	}
+
+	public boolean isWaitingForFederates()
+	{
+		return this.isWaitingForFederates;
 	}
 
 	public boolean canStart()
@@ -348,6 +356,8 @@ public class FedManFederate extends NoOpFederate
 		int lastJoinedCount = -1;
 		int currentJoinedCount = startRequirements.joinedCount();
 
+		// we are currently waiting for federates to join
+		this.isWaitingForFederates = true;
 		while( !startRequirements.canStart() )
 		{
 			currentJoinedCount = startRequirements.joinedCount();
@@ -371,6 +381,8 @@ public class FedManFederate extends NoOpFederate
 			}
 			count++;
 		}
+		// we have all our required federates - we're not waiting any more
+		this.isWaitingForFederates = false;
 
 		System.out.println( String.format( "\n%d of %d federates have joined.",
 		                                   startRequirements.totalFederatesRequired(),


### PR DESCRIPTION
The federation manager has a new endpoint which allows querying of a "waiting for federates to join" condition - this is essentially the period from when the federation manager begins waiting for federates to join in order to meet its start condition requirements until those start requirements are met.

The start batch scripts have been updated to poll this endpoint with a `curl` command to determine when is the best time to actually start the federates.