### PR TITLE
Federation Manager Configuration from JSON

### DIFF
--- a/src/java/ucef-java-core/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
+++ b/src/java/ucef-java-core/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
@@ -755,19 +755,25 @@ public abstract class FederateBase
 	protected void enableTimePolicy()
 	{
 		// enable time regulation based on configuration
-		rtiamb.enableTimeRegulation( configuration.getLookAhead() );
-		while( fedamb.isTimeRegulated() == false )
+		if( configuration.isTimeRegulated() )
 		{
-			// waiting for callback to confirm it's enabled
-			tickForCallBacks();
+			rtiamb.enableTimeRegulation( configuration.getLookAhead() );
+			while( fedamb.isTimeRegulated() == false )
+			{
+				// waiting for callback to confirm it's enabled
+				tickForCallBacks();
+			}
 		}
 
-		// enable time constrained
-		rtiamb.enableTimeConstrained();
-		while( fedamb.isTimeConstrained() == false )
+		// enable time constrained based on configuration
+		if( configuration.isTimeConstrained() )
 		{
-			// waiting for callback to confirm it's enabled
-			tickForCallBacks();
+			rtiamb.enableTimeConstrained();
+			while( fedamb.isTimeConstrained() == false )
+			{
+				// waiting for callback to confirm it's enabled
+				tickForCallBacks();
+			}
 		}
 	}
 

--- a/src/java/ucef-java-core/src/main/java/gov/nist/ucef/hla/base/FederateConfiguration.java
+++ b/src/java/ucef-java-core/src/main/java/gov/nist/ucef/hla/base/FederateConfiguration.java
@@ -80,6 +80,8 @@ public class FederateConfiguration
 	private static final boolean DEFAULT_ARE_CALLBACKS_IMMEDIATE  = true;
 	private static final double DEFAULT_LOOK_AHEAD                = 1.0;
 	private static final double DEFAULT_STEP_SIZE                 = 0.1;
+	private static final boolean DEFAULT_IS_TIME_CONSTRAINED      = true;
+	private static final boolean DEFAULT_IS_TIME_REGULATED        = true;
 
 	// keys for locating values in JSON based configuration data
 	private static final String JSON_CONFIG_KEY_FEDERATE_NAME           = "federateName";
@@ -92,6 +94,8 @@ public class FederateConfiguration
 	private static final String JSON_CONFIG_KEY_SYNC_BEFORE_RESIGN      = "syncBeforeResign";
 	private static final String JSON_CONFIG_KEY_CALLBACKS_ARE_IMMEDIATE = "callbacksAreImmediate";
 	private static final String JSON_CONFIG_KEY_LOOK_AHEAD              = "lookAhead";
+	private static final String JSON_CONFIG_KEY_TIME_CONSTRAINED        = "timeConstrained";
+	private static final String JSON_CONFIG_KEY_TIME_REGULATED          = "timeRegulated";
 	private static final String JSON_CONFIG_KEY_BASE_FOMS               = "base-foms";
 	private static final String JSON_CONFIG_KEY_JOIN_FOMS               = "join-foms";
 	private static final String JSON_CONFIG_KEY_SOM                     = "som";
@@ -122,6 +126,8 @@ public class FederateConfiguration
 	private boolean callbacksAreImmediate;
 	private double lookAhead;
 	private double stepSize;
+	private boolean isTimeConstrained;
+	private boolean isTimeRegulated;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -168,6 +174,9 @@ public class FederateConfiguration
 		this.callbacksAreImmediate = DEFAULT_ARE_CALLBACKS_IMMEDIATE;
 		this.lookAhead = DEFAULT_LOOK_AHEAD;
 		this.stepSize = DEFAULT_STEP_SIZE;
+
+		this.isTimeConstrained = DEFAULT_IS_TIME_CONSTRAINED;
+		this.isTimeRegulated = DEFAULT_IS_TIME_REGULATED;
 	}
 
 	//----------------------------------------------------------
@@ -277,6 +286,8 @@ public class FederateConfiguration
 	                JSON_CONFIG_KEY_SYNC_BEFORE_RESIGN,
 	                JSON_CONFIG_KEY_CALLBACKS_ARE_IMMEDIATE,
 	                JSON_CONFIG_KEY_LOOK_AHEAD,
+	            	JSON_CONFIG_KEY_TIME_CONSTRAINED,
+	            	JSON_CONFIG_KEY_TIME_REGULATED,
 	                JSON_CONFIG_KEY_STEP_SIZE,
 	                JSON_CONFIG_KEY_BASE_FOMS,
 	                JSON_CONFIG_KEY_JOIN_FOMS,
@@ -327,6 +338,12 @@ public class FederateConfiguration
 			this.callbacksAreImmediate = jsonBooleanOrDefault( configData,
 			                                                   JSON_CONFIG_KEY_CALLBACKS_ARE_IMMEDIATE,
 			                                                   this.callbacksAreImmediate );
+			this.isTimeConstrained = jsonBooleanOrDefault( configData,
+			                                               JSON_CONFIG_KEY_TIME_CONSTRAINED,
+			                                               this.isTimeConstrained );
+			this.isTimeRegulated = jsonBooleanOrDefault( configData,
+			                                             JSON_CONFIG_KEY_TIME_REGULATED,
+			                                             this.isTimeRegulated );
 			this.lookAhead = jsonDoubleOrDefault( configData,
 			                                      JSON_CONFIG_KEY_LOOK_AHEAD,
 			                                      this.lookAhead );
@@ -717,7 +734,6 @@ public class FederateConfiguration
 		return lookAhead;
 	}
 
-
 	/**
 	 * Configure the federate's step size
 	 *
@@ -738,6 +754,50 @@ public class FederateConfiguration
 	public double getStepSize()
 	{
 		return stepSize;
+	}
+
+	/**
+	 * Configure the federate's time constraint policy
+	 *
+	 * @param isTimeRegulated true if time constraint is enabled, false otherwise
+	 * @return this instance (for method chaining)
+	 */
+	public FederateConfiguration setTimeConstrained( boolean isTimeConstrained )
+	{
+		this.isTimeConstrained = isTimeConstrained;
+		return this;
+	}
+
+	/**
+	 * Obtain the federate's time constraint policy
+	 *
+	 * @return the federate's time constraint policy
+	 */
+	public boolean isTimeConstrained()
+	{
+		return this.isTimeConstrained;
+	}
+
+	/**
+	 * Configure the federate's time regulation policy
+	 *
+	 * @param isTimeRegulated true if time reglulation is enabled, false otherwise
+	 * @return this instance (for method chaining)
+	 */
+	public FederateConfiguration setTimeRegulated( boolean isTimeRegulated )
+	{
+		this.isTimeRegulated = isTimeRegulated;
+		return this;
+	}
+
+	/**
+	 * Obtain the federate's time regulation policy
+	 *
+	 * @return the federate's time regulation policy
+	 */
+	public boolean isTimeRegulated()
+	{
+		return this.isTimeRegulated;
 	}
 
 	/**

--- a/src/java/ucef-java-core/src/test/java/gov/nist/ucef/hla/base/common/HLACodecUtilsTest.java
+++ b/src/java/ucef-java-core/src/test/java/gov/nist/ucef/hla/base/common/HLACodecUtilsTest.java
@@ -104,7 +104,7 @@ public class HLACodecUtilsTest extends TestCase
 			// run through an encode/decode cycle, should come out the same
 			int actual = HLACodecUtils.asInt( this.encoder,
 			                                  HLACodecUtils.encode( this.encoder, expected ) );
-			assertEquals( expected, actual );
+ 			assertEquals( expected, actual );
 		}
 	}
 

--- a/src/java/ucef-java-genx-pong/.vscode/settings.json
+++ b/src/java/ucef-java-genx-pong/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#65c89b",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#945bc4",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "titleBar.activeBackground": "#42b883",
+        "titleBar.inactiveBackground": "#42b88399",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveForeground": "#15202b99",
+        "statusBar.background": "#42b883",
+        "statusBarItem.hoverBackground": "#359268",
+        "statusBar.foreground": "#15202b"
+    }
+}

--- a/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManCmdLineProcessor.java
+++ b/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManCmdLineProcessor.java
@@ -23,8 +23,14 @@
  */
 package gov.nist.ucef.hla.tools.fedman;
 
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -34,35 +40,49 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PatternOptionBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import gov.nist.ucef.hla.base.UCEFException;
 
 public class FedManCmdLineProcessor
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
-	// command line arguments and defaults
-	private static final String CMDLINE_ARG_HELP                       = "help";
-	private static final String CMDLINE_ARG_HELP_SHORT                 = "h";
-	private static final String CMDLINEARG_FEDMAN_FEDERATION_EXEC_NAME = "federation";
-	private static final String CMDLINE_ARG_FEDERATION_EXEC_NAME_SHORT = "f";
-	private static final String CMDLINEARG_REQUIRE                     = "require";
-	private static final String CMDLINEARG_REQUIRE_SHORT               = "r";
-	private static final String CMDLINEARG_FEDMAN_FEDERATE_NAME        = "fedman-name";
-	private static final String DEFAULT_FEDMAN_FEDERATE_NAME           = "FederateManager";
-	private static final String CMDLINEARG_FEDMAN_FEDERATE_TYPE        = "fedman-type";
-	private static final String DEFAULT_FEDMAN_FEDERATE_TYPE           = "FederateManager";
-	private static final String CMDLINEARG_MAX_TIME                    = "max-time";
-	private static final String CMDLINEARG_LOGICAL_SECOND              = "logical-second";
-	private static final String CMDLINEARG_LOGICAL_STEP_GRANULARITY    = "logical-granularity";
-	private static final String CMDLINEARG_REALTIME_MULTIPLIER         = "realtime-multiplier";
-	private static final String CMDLINEARG_NO_HTTP                     = "no-http";
-	private static final String CMDLINEARG_HTTP_PORT                   = "http-port";
-	private static final String CMDLINEARG_CONFIG_FILE                 = "config";
+	private static final Logger logger = LogManager.getLogger( FedManCmdLineProcessor.class );
 
+	// command line arguments
+	private static final String CMDLINE_ARG_HELP                        = "help";
+	private static final String CMDLINE_ARG_HELP_SHORT                  = "h";
+	private static final String CMDLINE_ARG_JSON_CONFIG_FILE            = "config";
+	private static final String CMDLINE_ARG_FEDMAN_FEDERATION_EXEC_NAME = "federation-name";
+	private static final String CMDLINE_ARG_FEDERATION_EXEC_NAME_SHORT  = "f";
+	private static final String CMDLINE_ARG_REQUIRE                     = "require";
+	private static final String CMDLINE_ARG_REQUIRE_SHORT               = "r";
+	private static final String CMDLINE_ARG_FEDMAN_FEDERATE_NAME        = "fedman-name";
+	private static final String CMDLINE_ARG_FEDMAN_FEDERATE_TYPE        = "fedman-type";
+	private static final String CMDLINE_ARG_MAX_TIME                    = "max-time";
+	private static final String CMDLINE_ARG_LOGICAL_SECOND              = "logical-second";
+	private static final String CMDLINE_ARG_LOGICAL_STEP_GRANULARITY    = "logical-granularity";
+	private static final String CMDLINE_ARG_REALTIME_MULTIPLIER         = "realtime-multiplier";
+	private static final String CMDLINE_ARG_HTTP_PORT                   = "http-port";
+	private static final String CMDLINE_SWITCH_NO_HTTP_SERVICE          = "no-http-service";
+
+	// JSON config keys (mostly the same as command line arguments)
+	private static final String JSON_CONFIG_KEY_WITH_HTTP               = "http-service";
+
+	// default config values, as required
+	private static final String FEDMAN_FEDERATE_NAME_DEFAULT           = "FederationManager";
+	private static final String FEDMAN_FEDERATE_TYPE_DEFAULT           = FEDMAN_FEDERATE_NAME_DEFAULT;
 	private static final double MAX_TIME_DEFAULT                       = Double.MAX_VALUE;
 	private static final double LOGICAL_SECOND_DEFAULT                 = 1.0;
 	private static final int LOGICAL_STEP_GRANULARITY_DEFAULT          = 1;
 	private static final double REALTIME_MULTIPLIER_DEFAULT            = 1.0;
+	private static final boolean HTTP_SERVICE_ACTIVE_DEFAULT           = true;
 	private static final int HTTP_PORT_DEFAULT                         = 8080;
 
 	//----------------------------------------------------------
@@ -76,7 +96,7 @@ public class FedManCmdLineProcessor
 	private double logicalSecond;
 	private int logicalStepGranularity;
 	private double realtimeMultiplier;
-	private boolean withHttpService;
+	private boolean withHttpServiceActive;
 	private int httpServicePort;
 	private String configFile;
 
@@ -90,9 +110,19 @@ public class FedManCmdLineProcessor
 	public FedManCmdLineProcessor( String execName )
 	{
 		this.execName = execName;
-		this.startRequirements = new HashMap<>();
 
-		this.withHttpService = true;
+		// required arguments
+		this.federationExecName     = null;
+		this.startRequirements      = null;
+		// optional arguments
+		this.federateName           = FEDMAN_FEDERATE_NAME_DEFAULT;
+		this.federateType           = FEDMAN_FEDERATE_TYPE_DEFAULT;
+		this.withHttpServiceActive  = HTTP_SERVICE_ACTIVE_DEFAULT;
+		this.httpServicePort        = HTTP_PORT_DEFAULT;
+		this.maxTime                = MAX_TIME_DEFAULT;
+		this.logicalSecond          = LOGICAL_SECOND_DEFAULT;
+		this.logicalStepGranularity = LOGICAL_STEP_GRANULARITY_DEFAULT;
+		this.realtimeMultiplier     = REALTIME_MULTIPLIER_DEFAULT;
 
 		buildCommandLineOptions();
 	}
@@ -106,6 +136,16 @@ public class FedManCmdLineProcessor
 		String header = "Manages and coordinates federates in a federation.\n\n";
 		String footer = "\n";
 		helpFormatter.printHelp(this.execName, header, this.cmdLineOptions, footer, true);
+	}
+
+	public boolean hasFederationExecName()
+	{
+		return this.federationExecName != null;
+	}
+
+	public boolean hasStartRequirements()
+	{
+		return this.startRequirements != null;
 	}
 
 	public String federationExecName()
@@ -156,12 +196,12 @@ public class FedManCmdLineProcessor
 
 	public FedManStartRequirements startRequirements()
 	{
-		return new FedManStartRequirements(this.startRequirements);
+		return new FedManStartRequirements( this.startRequirements );
 	}
 
-	public boolean withHttpService()
+	public boolean withHttpServiceActive()
 	{
-		return this.withHttpService;
+		return this.withHttpServiceActive;
 	}
 
 	public int httpServicePort()
@@ -173,12 +213,12 @@ public class FedManCmdLineProcessor
 	{
 		return this.configFile != null && this.configFile.length() > 0;
 	}
-	
+
 	public String configFile()
 	{
 		return this.configFile;
 	}
-	
+
 	/**
 	 * Utility method for validating and processing of command line arguments/options
 	 *
@@ -212,45 +252,58 @@ public class FedManCmdLineProcessor
 		// At this stage we know that all required command line arguments are present,
 		// but we still need to validate the arguments
 
-        // this is a required argument, so we don't need to check if it's set, but we now need to
-        // check that it's valid
-        this.startRequirements = extractStartRequirements(cmdLine, CMDLINEARG_REQUIRE);
+		// pull data from configuration file if specified - we do this FIRST of all
+		// so that command line argument values take precendence over any config file values
+		this.configFile = extractCmdLineString( cmdLine, CMDLINE_ARG_JSON_CONFIG_FILE, "" );
+		if( isConfigFileSpecified() )
+		{
+			extractConfigFromJSON( this.configFile );
+		}
 
-        // this is a *required* argument, so we don't need to check if it's set
-        this.federationExecName = extractString( cmdLine, CMDLINEARG_FEDMAN_FEDERATION_EXEC_NAME, "" );
+		// note that this is not "required" to be in the command line args, but must be specified by
+		// either the command line or from JSON configuration data by the time we start up
+		Map<String,Integer> tempStartRequirements = extractCmdLineStartRequirements( cmdLine,
+		                                                                             CMDLINE_ARG_REQUIRE );
+		if( tempStartRequirements != null )
+			this.startRequirements = tempStartRequirements;
+		// note that this is not "required" to be in the command line args, but must be specified by
+		// either the command line or from JSON configuration data by the time we start up
+		String tempFederationExecName =
+		    extractCmdLineString( cmdLine, CMDLINE_ARG_FEDMAN_FEDERATION_EXEC_NAME, null );
+		if( tempFederationExecName != null )
+			this.federationExecName = tempFederationExecName;
+
         // optional arguments
-        this.federateName = extractString( cmdLine,
-                                           CMDLINEARG_FEDMAN_FEDERATE_NAME,
-                                           DEFAULT_FEDMAN_FEDERATE_NAME );
-        this.federateType = extractString( cmdLine,
-                                           CMDLINEARG_FEDMAN_FEDERATE_TYPE,
-                                           DEFAULT_FEDMAN_FEDERATE_TYPE );
+        this.federateName = extractCmdLineString( cmdLine,
+                                           CMDLINE_ARG_FEDMAN_FEDERATE_NAME,
+                                           FEDMAN_FEDERATE_NAME_DEFAULT );
+        this.federateType = extractCmdLineString( cmdLine,
+                                           CMDLINE_ARG_FEDMAN_FEDERATE_TYPE,
+                                           FEDMAN_FEDERATE_TYPE_DEFAULT );
 
         // NOTE that this is a bit of a double negative - the lack of the
         //      no-http switch means that withHttpService is true.
-        this.withHttpService = !cmdLine.hasOption( CMDLINEARG_NO_HTTP );
-        this.httpServicePort = extractInRangeInt( cmdLine,
-                                                  CMDLINEARG_HTTP_PORT,
+        this.withHttpServiceActive = !cmdLine.hasOption( CMDLINE_SWITCH_NO_HTTP_SERVICE );
+        this.httpServicePort = extractCmdLineInRangeInt( cmdLine,
+                                                  CMDLINE_ARG_HTTP_PORT,
                                                   0, 65535,
                                                   HTTP_PORT_DEFAULT );
-        
-        this.configFile = extractString( cmdLine, CMDLINEARG_CONFIG_FILE, "" );
 
         // we need to sanity check some arguments with respect to each other
         // to ensure that they are "sensible" - in other words, the values
         // are all fine individually, but in combination they might cause
         // some problems
-        this.maxTime = extractGtZeroDouble( cmdLine,
-                                            CMDLINEARG_MAX_TIME,
+        this.maxTime = extractCmdLineGtZeroDouble( cmdLine,
+                                            CMDLINE_ARG_MAX_TIME,
                                             MAX_TIME_DEFAULT );
-		this.logicalSecond = extractGtZeroDouble( cmdLine,
-		                                          CMDLINEARG_LOGICAL_SECOND,
+		this.logicalSecond = extractCmdLineGtZeroDouble( cmdLine,
+		                                          CMDLINE_ARG_LOGICAL_SECOND,
 		                                          LOGICAL_SECOND_DEFAULT );
-		this.logicalStepGranularity = extractGtZeroInt( cmdLine,
-		                                                CMDLINEARG_LOGICAL_STEP_GRANULARITY,
+		this.logicalStepGranularity = extractCmdLineGtZeroInt( cmdLine,
+		                                                CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
 		                                                LOGICAL_STEP_GRANULARITY_DEFAULT );
-		this.realtimeMultiplier = extractGtZeroDouble( cmdLine,
-		                                               CMDLINEARG_REALTIME_MULTIPLIER,
+		this.realtimeMultiplier = extractCmdLineGtZeroDouble( cmdLine,
+		                                               CMDLINE_ARG_REALTIME_MULTIPLIER,
 		                                               REALTIME_MULTIPLIER_DEFAULT );
 
 		double oneSecond = 1000.0 / this.realtimeMultiplier;
@@ -262,9 +315,9 @@ public class FedManCmdLineProcessor
 			System.err.println( String.format( "The specified value(s) for " +
 											   "--%s, --%s and/or --%s " +
 			                                   " cannot be achieved (tick rate is too high).",
-			                                   CMDLINEARG_LOGICAL_SECOND,
-			                                   CMDLINEARG_LOGICAL_STEP_GRANULARITY,
-			                                   CMDLINEARG_REALTIME_MULTIPLIER ) );
+			                                   CMDLINE_ARG_LOGICAL_SECOND,
+			                                   CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
+			                                   CMDLINE_ARG_REALTIME_MULTIPLIER ) );
 			return false;
 		}
 		else if( wallClockStepDelay < 20 )
@@ -274,13 +327,518 @@ public class FedManCmdLineProcessor
 											   "requires a tick rate higher than 50 ticks" +
 											   "per second - your simulation may not " +
 											   "keep up with your requirements.",
-											   CMDLINEARG_LOGICAL_SECOND,
-											   CMDLINEARG_LOGICAL_STEP_GRANULARITY,
-											   CMDLINEARG_REALTIME_MULTIPLIER ) );
+											   CMDLINE_ARG_LOGICAL_SECOND,
+											   CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
+											   CMDLINE_ARG_REALTIME_MULTIPLIER ) );
 		}
 
 		// all command line arguments are present and correct!
 		return true;
+	}
+
+	/**
+	 * Obtain a {@link File} resource instance based on a path. The resource is looked for on the
+	 * file system and as a resource (as in a packaged JAR)
+	 *
+	 * @param path the path for the resource
+	 * @return the resource as a {@link File} instance, or null if no such resource could be
+	 *         located
+	 */
+	private File getResourceFile( String path )
+	{
+		File file = new File( path );
+		if( file.exists() && file.isFile() )
+			return file;
+
+		URL fileUrl = this.getClass().getClassLoader().getResource( path );
+		if( fileUrl != null )
+			return new File( fileUrl.getFile() );
+
+		return null;
+	}
+
+	private void extractConfigFromJSON( String jsonConfigSource )
+	{
+		// see if the configuration source is a file
+		File configFile = getResourceFile( jsonConfigSource );
+		boolean isFile = configFile != null;
+
+		// assume for the moment that the JSON is coming directly from the
+		// configuration source parameter
+		String json = jsonConfigSource;
+		if(isFile)
+		{
+			// the configuration source is actually a file - read the bytes
+			// from it into a string for processing
+			try
+			{
+				json = new String( Files.readAllBytes( configFile.toPath() ) );
+			}
+			catch( Exception e )
+			{
+				throw new UCEFException( e, "Unable to read JSON configuration from '%s'.",
+				                         configFile.getAbsolutePath() );
+			}
+		}
+
+		// at this point, we have a string to work with - make sure it's valid JSON
+		Object parsedString = null;
+		try
+		{
+			parsedString = new JSONParser().parse(json);
+		}
+		catch( Exception e )
+		{
+			String msg = "Configuration is not valid JSON.";
+			if(isFile)
+			{
+				msg = String.format( "Configuration is not valid JSON in '%s'.",
+				                     configFile.getAbsolutePath() );
+			}
+			throw new UCEFException( e, msg );
+		}
+
+		// at this point, we have a valid JSON object of some form, but we
+		// need to make sure that it is a single JSONObject instance (and
+		// not something else like a JSONArray)
+		if(!(parsedString instanceof JSONObject))
+		{
+			String msg = "Could not find root JSON object.";
+			if(isFile)
+			{
+				msg = String.format( "Could not find root JSON object in '%s'.",
+				                     configFile.getAbsolutePath() );
+			}
+			throw new UCEFException( msg );
+		}
+
+		// we now have a JSONObject to extract data from
+		JSONObject configData = (JSONObject)parsedString;
+
+		if(logger.isWarnEnabled())
+		{
+			// for the purposes of debugging problems, show warnings for
+			// any unrecognized configuration items found so that
+			// problems can be resolved quickly (such as typos in the
+			// config JSON keys etc)
+			Set<String> recognizedConfigurationKeys = new HashSet<>();
+			recognizedConfigurationKeys.addAll( Arrays.asList(new String[]
+				{
+				    CMDLINE_ARG_REQUIRE,
+					CMDLINE_ARG_FEDMAN_FEDERATION_EXEC_NAME,
+					CMDLINE_ARG_FEDMAN_FEDERATE_NAME,
+					CMDLINE_ARG_FEDMAN_FEDERATE_TYPE,
+					CMDLINE_ARG_MAX_TIME,
+					CMDLINE_ARG_LOGICAL_SECOND,
+					CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
+					CMDLINE_ARG_REALTIME_MULTIPLIER,
+					CMDLINE_SWITCH_NO_HTTP_SERVICE,
+					CMDLINE_ARG_HTTP_PORT
+				}
+			));
+			for(Object key : configData.keySet())
+			{
+				if(!recognizedConfigurationKeys.contains( key ))
+				{
+					Object value = configData.get(key);
+					logger.warn( String.format( "Configuration item '%s' with "+
+												"value '%s' in JSON configuration data "+
+												"is not recognized and will be ignored.",
+					                            key.toString(), value.toString() )
+					);
+				}
+			}
+		}
+
+		// now we can process the configuration data from the JSONObject
+		try
+		{
+			// process configuration - note that in *all* cases we try to look
+			// up the value from the JSON and fall back to the existing value
+			// if there is no value available
+
+			// note that this is not "required" to be in the JSON, but must be specified by either
+			// the command line or from JSON configuration data by the time we start up
+			String tempFederationExecName = extractJsonNonEmptyString( configData,
+			                                                           CMDLINE_ARG_FEDMAN_FEDERATION_EXEC_NAME,
+			                                                           null );
+			if( tempFederationExecName != null )
+				this.federationExecName = tempFederationExecName;
+			// note that this is not "required" to be in the JSON, but must be specified by either
+			// the command line or from JSON configuration data by the time we start up
+			Map<String,Integer> tempStartRequirements = extractJsonStartRequirements( configData,
+			                                                                          CMDLINE_ARG_REQUIRE );
+			if( tempStartRequirements != null )
+				this.startRequirements = tempStartRequirements;
+
+			this.federateName = extractJsonNonEmptyString( configData,
+			                                               CMDLINE_ARG_FEDMAN_FEDERATE_NAME,
+			                                               this.federateName );
+			this.federateType = extractJsonNonEmptyString( configData,
+			                                               CMDLINE_ARG_FEDMAN_FEDERATE_TYPE,
+			                                               this.federateType );
+			this.maxTime = extractJsonGtZeroDouble( configData, CMDLINE_ARG_MAX_TIME, this.maxTime );
+			this.logicalSecond = extractJsonGtZeroDouble( configData,
+			                                          CMDLINE_ARG_LOGICAL_SECOND,
+			                                          this.logicalSecond );
+			this.logicalStepGranularity = extractJsonGtZeroInt( configData,
+			                                                    CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
+			                                                    this.logicalStepGranularity );
+			this.realtimeMultiplier = extractJsonGtZeroDouble( configData,
+			                                                   CMDLINE_ARG_REALTIME_MULTIPLIER,
+			                                                   this.realtimeMultiplier );
+			this.withHttpServiceActive = extractJsonBoolean( configData,
+			                                                 JSON_CONFIG_KEY_WITH_HTTP,
+			                                                 this.withHttpServiceActive );
+			this.httpServicePort = extractJsonInRangeInt( configData,
+			                                              CMDLINE_ARG_HTTP_PORT,
+			                                              0, 65535,
+			                                              this.httpServicePort );
+		}
+		catch( Exception e )
+		{
+			String msg = "There was a problem processing the configuration JSON.";
+			if(isFile)
+			{
+				msg = String.format( "There was a problem processing the configuration JSON in '%s'.",
+				                     configFile.getAbsolutePath() );
+			}
+			throw new UCEFException( e, msg );
+		}
+	}
+
+	/**
+	 * Utility method to extract a {@link String} value from a {@link JSONObject} based on a
+	 * {@link String} key
+	 *
+	 * If the value extracted from the key is not a string, the value is rejected, and
+	 * a {@link UCEFException} will be thrown in this case.
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return if the provided {@link JSONObject} does not contain
+	 *            the given {@link String} key
+	 * @return the extracted value, or the default value if there was no such key
+	 */
+	private String extractJsonString( JSONObject root, String key, String defaultValue )
+	{
+		if( root.containsKey( key ) )
+		{
+			Object value = root.get( key );
+			if( value instanceof String )
+			{
+				if(logger.isDebugEnabled())
+					logger.debug( String.format( "Found value '%s' for item '%s' in configuration file", value, key ) );
+
+				return value.toString();
+			}
+
+			throw new UCEFException( "Expected a string value for '%s' but found '%s' in configuration file",
+			                         key, value.toString() );
+		}
+		if(logger.isDebugEnabled())
+    		logger.debug( String.format( "No value found for '%s' in configuration file, using default value '%s'", key, defaultValue ) );
+
+		return defaultValue;
+	}
+
+	/**
+	 * Utility method to extract a {@link String} value from a {@link JSONObject} based on a
+	 * {@link String} key
+	 *
+	 * If the value extracted from the key is not a string, the value is rejected, and
+	 * a {@link UCEFException} will be thrown in this case.
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return if the provided {@link JSONObject} does not contain
+	 *            the given {@link String} key
+	 * @return the extracted value, or the default value if there was no such key
+	 */
+	private String extractJsonNonEmptyString( JSONObject root, String key, String defaultValue ) throws ParseException
+	{
+		String value = extractJsonString( root, key, defaultValue );
+		if( value == null || value.trim().length() > 0 )
+			return value;
+		throw new ParseException( String.format( "Value for '%s' in configuration file may not be "+
+												 "an empty string or consist only of whitespace.",
+		                                         key ) );
+	}
+
+	/**
+	 * Utility method to extract an {@link Integer} value from a {@link JSONObject} based on a
+	 * {@link String} key
+	 *
+	 * If the value extracted from the key is not an integer, the value is rejected, and
+	 * a {@link UCEFException} will be thrown in this case.
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return if the provided {@link JSONObject} does not contain
+	 *            the given {@link String} key
+	 * @return the extracted value, or the default value if there was no such key
+	 */
+	private int extractJsonInt( JSONObject root, String key, int defaultValue )
+	{
+		if( root.containsKey( key ) )
+		{
+			Object value = root.get( key );
+			// integers in JSON data are actually parsed out as longs
+			if( value instanceof Long )
+			{
+				if(logger.isDebugEnabled())
+					logger.debug( String.format( "Found value '%s' for item '%s' in configuration file.", value, key ) );
+
+				return ((Long)value).intValue();
+			}
+
+			throw new UCEFException( "Expected an integer value for '%s' but found '%s' in configuration file.",
+			                         key, value.toString() );
+		}
+		if(logger.isDebugEnabled())
+    		logger.debug( String.format( "No value found for '%s' in configuration file, using default value '%s'", key, defaultValue ) );
+
+		return defaultValue;
+	}
+
+	/**
+	 * Utility method to extract a {@link Integer} from a JSON object, ensuring that the
+	 * extracted value is greater than 0
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return in the event that no such value is specified in the
+	 *            given {@link JSONObject} instance
+	 * @return the extracted value, or default value in the case that no value could be extracted
+	 * @throws ParseException if the extracted value cannot be processed as a {@link Integer}, or
+	 *             the value is zero or less
+	 */
+	private int extractJsonGtZeroInt( JSONObject root, String key, int defaultValue )
+	    throws ParseException
+	{
+		int value = extractJsonInt( root, key, defaultValue );
+		if( value > 0.0 )
+			return value;
+		throw new ParseException( String.format( "Value for '%s' in configuration file must be a "+
+												 "whole number greater than zero.",
+		                                         key ) );
+	}
+
+	/**
+	 * Utility method to extract a {@link Integer} from a JSON object, ensuring that the
+	 * extracted value is between the provided minimum and maximum values (inclusive)
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param min the minimum allowed value (inclusive)
+	 * @param max the maximum allowed value (inclusive)
+	 * @param defaultValue the value to return in the event that no such value is specified in the
+	 *            given {@link JSONObject} instance
+	 * @return the extracted value, or default value in the case that no value could be extracted
+	 * @throws ParseException if the extracted value cannot be processed as an {@link Integer}, or
+	 *             the value is outside the allowed range
+	 */
+	private int extractJsonInRangeInt( JSONObject root, String key, int min, int max, int defaultValue )
+		throws ParseException
+	{
+		int value = extractJsonInt( root, key, defaultValue );
+		if( value >= min && value <= max )
+			return value;
+		throw new ParseException( String.format( "Value for '%s' in configuration file must be a " +
+												 "whole number between %d and %d (inclusive).",
+		                                         key, min, max ) );
+	}
+
+
+	/**
+	 * Utility method to extract a {@link Double} value from a {@link JSONObject} based on a
+	 * {@link String} key.
+	 *
+	 * The content associated with the key is expected to be a double. However it will
+	 * also leniently treat an integer as a double.
+	 *
+	 * If the value extracted from the key is not a double, the value is rejected, and
+	 * a {@link UCEFException} will be thrown in this case.
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return if the provided {@link JSONObject} does not contain
+	 *            the given {@link String} key
+	 * @return the extracted value, or the default value if there was no such key
+	 */
+	private double extractJsonDouble( JSONObject root, String key, double defaultValue )
+	{
+		if( root.containsKey( key ) )
+		{
+			Object value = root.get( key );
+			if( value instanceof Double )
+			{
+				if(logger.isDebugEnabled())
+					logger.debug( String.format( "Found value '%s' for item '%s' in configuration file", value, key ) );
+
+				return (Double)value;
+			}
+			// be lenient on the parsing of doubles, and allow integer
+			// values to get through as well
+			if( value instanceof Long )
+			{
+				if(logger.isDebugEnabled())
+					logger.debug( String.format( "Found value '%s' for item '%s' in configuration file", value, key ) );
+
+				return ((Long)value).doubleValue();
+			}
+
+			throw new UCEFException( "Expected a double value for '%s' but found '%s' in configuration file",
+			                         key, value.toString() );
+		}
+		if(logger.isDebugEnabled())
+    		logger.debug( String.format( "No value found for '%s' in configuration file, using default value '%s'", key, defaultValue ) );
+
+		return defaultValue;
+	}
+
+	/**
+	 * Utility method to extract a {@link Double} from JSON object, ensuring that the
+	 * extracted value is greater than 0.0
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return in the event that no such value is specified in the
+	 *            given {@link CommandLine} instance
+	 * @return the extracted value, or default value in the case that no value could be extracted
+	 * @throws ParseException if the extracted value cannot be processed as a {@link Double}, or
+	 *             the value is zero or less
+	 */
+	private double extractJsonGtZeroDouble( JSONObject root, String key, double defaultValue )
+	    throws ParseException
+	{
+		double value = extractJsonDouble( root, key, defaultValue );
+		if( value > 0.0 )
+			return value;
+		throw new ParseException( String.format( "Value for '%s' in configuration file must be a "+
+												 "numeric value greater than zero.",
+		                                         key ) );
+	}
+
+	/**
+	 * Utility method to extract a {@link Boolean} value from a {@link JSONObject} based on a
+	 * {@link String} key
+	 *
+	 * If the value extracted from the key is not a boolean, the value is rejected, and
+	 * a {@link UCEFException} will be thrown in this case.
+	 *
+	 * @param root the {@link JSONObject} which is expected to contain the value under the key
+	 * @param key the {@link String} key to retrieve the value with
+	 * @param defaultValue the value to return if the provided {@link JSONObject} does not contain
+	 *            the given {@link String} key
+	 * @return the extracted value, or the default value if there was no such key
+	 */
+	private boolean extractJsonBoolean( JSONObject root, String key, boolean defaultValue )
+	{
+		if( root.containsKey( key ) )
+		{
+			Object value = root.get( key );
+			if( value instanceof Boolean )
+			{
+				if(logger.isDebugEnabled())
+					logger.debug( String.format( "Found value '%s' for item '%s' in configuration file", value, key ) );
+
+				return (Boolean)value;
+			}
+
+			throw new UCEFException( "Expected a boolean value for '%s' but found '%s' in configuration file",
+			                         key, value.toString() );
+		}
+		if(logger.isDebugEnabled())
+    		logger.debug( String.format( "No value found for '%s' in configuration file, using default value '%s'", key, defaultValue ) );
+
+		return defaultValue;
+	}
+
+	/**
+	 * Utility method to extract a {@link Map<String, Integer>} from a JSON object, which
+	 * represents the start requirements for the federation as federate types to minimum counts
+	 *
+	 * @param root the {@link JSONObject} instance
+	 * @param key the {@link String} key to identify the value to be extracted
+	 * @return the extracted value, or null if no value for the specified key exists
+	 * @throws ParseException if the extracted value cannot be processed
+	 */
+	private Map<String, Integer> extractJsonStartRequirements(JSONObject root, String key) throws ParseException
+	{
+		if(!root.containsKey( key ))
+			return null;
+
+		String typeKey = "type";
+		String countKey = "count";
+		String errorMsg = String.format( "'%s' is not in the correct format.%%s Values are expected " +
+		                                 "to be an array of JSON objects of the form " +
+		                                 "'{\"%s\":\"FEDERATE_TYPE\",\"%s\":COUNT}'. " +
+		                                 "Note that COUNT *must* be a whole number greater than zero. " +
+		                                 "For example, '{\"%s\":\"FedABC\",\"%s\":2}'.",
+		                                 key, typeKey, countKey, typeKey, countKey );
+		Object value = root.get( key );
+
+		// value must be a JSON array
+		if( !(value instanceof JSONArray) )
+			throw new ParseException( String.format( errorMsg, " The value was not a JSON array." ) );
+
+		JSONArray jsonArray = (JSONArray)value;
+		Map<String, Integer> result = new HashMap<String, Integer>();
+		// check all the values - each should be in the form...
+		//     {"type":"FEDERATE_TYPE","count":COUNT}
+		// ...where FEDERATE_TYPE is a string containing the federate type, and COUNT is an
+		// integer greater than 0 representing the number of that federate type required
+		int idx = 0;
+		for( Object item : jsonArray )
+		{
+			// each item in the array must be a JSON object
+			if( !(item instanceof JSONObject) )
+			{
+				String detail = String.format( " Item #%d in the array was not a JSON object.", idx );
+				throw new ParseException( String.format( errorMsg, detail ) );
+			}
+			JSONObject jsonObject = (JSONObject)item;
+
+			// the 'type' and 'count' keys must both be present on each and every item
+			if( !jsonObject.containsKey( typeKey ) || !jsonObject.containsKey( countKey ) )
+			{
+				String detail = String.format( " Item #%d in the array was missing the '%s' and/or '%s' key(s).", idx, typeKey, countKey );
+				throw new ParseException( String.format( errorMsg, detail ) );
+			}
+			Object typeCandidate = jsonObject.get( typeKey );
+
+			// the value associated with the 'type' key must be a non-empty String
+			if( !(typeCandidate instanceof String) )
+			{
+				String detail = String.format( " Item #%d in the array did not have a text value for '%s'.", idx, typeKey );
+				throw new ParseException( String.format( errorMsg, detail ) );
+			}
+			String typeValue = typeCandidate.toString().trim();
+			if( typeValue.length() == 0 )
+			{
+				String detail = String.format( " Item #%d in the array had an empty string for '%s'.", idx, typeKey );
+				throw new ParseException( String.format( errorMsg, detail ) );
+			}
+
+			// the value associated with the 'count' key must be an integer greater than zero
+			Object countCandidate = jsonObject.get( countKey );
+			if( !(countCandidate instanceof Long) )
+			{
+				String detail = String.format( " Item #%d in the array had an non-integer value for '%s'.", idx, countKey );
+				throw new ParseException( String.format( errorMsg, detail ) );
+			}
+			Long countValue = (Long)countCandidate;
+			if( countValue <= 0 )
+			{
+				String detail = String.format( " Item #%d in the array had an negative value for '%s'.", idx, countKey );
+				throw new ParseException( String.format( errorMsg, detail ) );
+			}
+
+			// everything checks out - add the details
+			result.put( typeValue, countValue.intValue() );
+		}
+		return result;
 	}
 
 	/**
@@ -293,7 +851,7 @@ public class FedManCmdLineProcessor
 	 * @return the extracted value, or default value in the case that no value could be extracted
 	 * @throws ParseException
 	 */
-	private String extractString(CommandLine cmdLine, String key, String defaultValue) throws ParseException
+	private String extractCmdLineString(CommandLine cmdLine, String key, String defaultValue) throws ParseException
 	{
 		if(!cmdLine.hasOption( key ))
 			return defaultValue;
@@ -311,7 +869,7 @@ public class FedManCmdLineProcessor
 	 * @return the extracted value, or default value in the case that no value could be extracted
 	 * @throws ParseException if the extracted value cannot be processed as a {@link Double}
 	 */
-	private double extractDouble(CommandLine cmdLine, String key, double defaultValue) throws ParseException
+	private double extractCmdLineDouble(CommandLine cmdLine, String key, double defaultValue) throws ParseException
 	{
 		if( !cmdLine.hasOption( key ) )
 			return defaultValue;
@@ -338,12 +896,12 @@ public class FedManCmdLineProcessor
 	 * @throws ParseException if the extracted value cannot be processed as a {@link Double}, or
 	 *             the value is zero or less
 	 */
-	private double extractGtZeroDouble( CommandLine cmdLine, String key, double defaultValue )
+	private double extractCmdLineGtZeroDouble( CommandLine cmdLine, String key, double defaultValue )
 	    throws ParseException
 	{
 		try
 		{
-			double value = extractDouble( cmdLine, key, defaultValue );
+			double value = extractCmdLineDouble( cmdLine, key, defaultValue );
 			if( value > 0.0 )
 				return value;
 		}
@@ -365,7 +923,7 @@ public class FedManCmdLineProcessor
 	 * @return the extracted value, or default value in the case that no value could be extracted
 	 * @throws ParseException if the extracted value cannot be processed as an {@link Integer}
 	 */
-	private int extractInt(CommandLine cmdLine, String key, int defaultValue) throws ParseException
+	private int extractCmdLineInt(CommandLine cmdLine, String key, int defaultValue) throws ParseException
 	{
 		if( !cmdLine.hasOption( key ) )
 			return defaultValue;
@@ -390,12 +948,12 @@ public class FedManCmdLineProcessor
 	 * @throws ParseException if the extracted value cannot be processed as an {@link Integer}, or
 	 *             the value is zero or less
 	 */
-	private int extractGtZeroInt( CommandLine cmdLine, String key, int defaultValue )
+	private int extractCmdLineGtZeroInt( CommandLine cmdLine, String key, int defaultValue )
 		throws ParseException
 	{
 		try
 		{
-			int value = extractInt( cmdLine, key, defaultValue );
+			int value = extractCmdLineInt( cmdLine, key, defaultValue );
 			if( value > 0 )
 				return value;
 		}
@@ -421,12 +979,12 @@ public class FedManCmdLineProcessor
 	 * @throws ParseException if the extracted value cannot be processed as an {@link Integer}, or
 	 *             the value is outside the allowed range
 	 */
-	private int extractInRangeInt( CommandLine cmdLine, String key, int min, int max, int defaultValue )
+	private int extractCmdLineInRangeInt( CommandLine cmdLine, String key, int min, int max, int defaultValue )
 		throws ParseException
 	{
 		try
 		{
-			int value = extractInt( cmdLine, key, defaultValue );
+			int value = extractCmdLineInt( cmdLine, key, defaultValue );
 			if( value >= min && value <= max )
 				return value;
 		}
@@ -448,8 +1006,11 @@ public class FedManCmdLineProcessor
 	 * @return the extracted value
 	 * @throws ParseException if the extracted value cannot be processed
 	 */
-	private Map<String, Integer> extractStartRequirements(CommandLine cmdLine, String key) throws ParseException
+	private Map<String, Integer> extractCmdLineStartRequirements(CommandLine cmdLine, String key) throws ParseException
 	{
+		if( !cmdLine.hasOption( key ) )
+			return null;
+
 		String[] values = cmdLine.getOptionValues( key );
 
 		boolean isValid = true;
@@ -512,20 +1073,39 @@ public class FedManCmdLineProcessor
 	{
 		Option help = Option.builder( CMDLINE_ARG_HELP_SHORT )
 			.longOpt( CMDLINE_ARG_HELP )
+			.required( false )
 			.desc("print this message and exit." )
 			.build();
 
+		// note that this is not "required", but must be specified by either the command line or
+		// from JSON configuration data by the time we start up
 		Option federationExecNameArg = Option.builder(CMDLINE_ARG_FEDERATION_EXEC_NAME_SHORT)
-        	.longOpt(CMDLINEARG_FEDMAN_FEDERATION_EXEC_NAME)
+        	.longOpt(CMDLINE_ARG_FEDMAN_FEDERATION_EXEC_NAME)
 			.hasArg()
         	.argName( "federation name" )
-        	.required( true )
+        	.required( false )
         	.desc( "Set the name of the federation the Federation Manager will join." )
 			.type( PatternOptionBuilder.STRING_VALUE )
         	.build();
 
+		// note that this is not "required", but must be specified by either the command line or
+		// from JSON configuration data by the time we start up
+        Option requiredFederateTypes = Option.builder( CMDLINE_ARG_REQUIRE_SHORT )
+        	.longOpt( CMDLINE_ARG_REQUIRE )
+			.hasArgs()
+        	.argName( "FEDERATE_TYPE,COUNT" )
+        	.required( false )
+		    .desc( String.format( "Define required federate types and minimum counts. For example, " +
+		                          "'-%s FedABC,2' would require at least two 'FedABC' type federates " +
+		                          "to join. Multiple requirements can be specified by repeated use " +
+		                          "of -%s.",
+		                          CMDLINE_ARG_REQUIRE_SHORT,
+		                          CMDLINE_ARG_REQUIRE_SHORT ) )
+			.type( PatternOptionBuilder.STRING_VALUE )
+		    .build();
+
         Option federateNameArg = Option.builder()
-        	.longOpt( CMDLINEARG_FEDMAN_FEDERATE_NAME )
+        	.longOpt( CMDLINE_ARG_FEDMAN_FEDERATE_NAME )
 			.hasArg()
         	.argName( "federate name" )
         	.required( false )
@@ -536,7 +1116,7 @@ public class FedManCmdLineProcessor
         	.build();
 
         Option federateTypeArg = Option.builder()
-        	.longOpt( CMDLINEARG_FEDMAN_FEDERATE_TYPE )
+        	.longOpt( CMDLINE_ARG_FEDMAN_FEDERATE_TYPE )
 			.hasArg()
         	.argName( "federate type" )
         	.required( false )
@@ -546,22 +1126,8 @@ public class FedManCmdLineProcessor
 			.type( PatternOptionBuilder.STRING_VALUE )
         	.build();
 
-        Option requiredFederateTypes = Option.builder( CMDLINEARG_REQUIRE_SHORT )
-        	.longOpt( CMDLINEARG_REQUIRE )
-			.hasArgs()
-        	.argName( "FEDERATE_TYPE,COUNT" )
-        	.required( true )
-		    .desc( String.format( "Define required federate types and minimum counts. For example, " +
-		                          "'-%s FedABC,2' would require at least two 'FedABC' type federates " +
-		                          "to join. Multiple requirements can be specified by repeated use " +
-		                          "of -%s.",
-		                          CMDLINEARG_REQUIRE_SHORT,
-		                          CMDLINEARG_REQUIRE_SHORT ) )
-			.type( PatternOptionBuilder.STRING_VALUE )
-		    .build();
-
         Option maxTimeArg = Option.builder()
-        	.longOpt( CMDLINEARG_MAX_TIME )
+        	.longOpt( CMDLINE_ARG_MAX_TIME )
 			.hasArg()
         	.argName( "max" )
         	.required( false )
@@ -571,7 +1137,7 @@ public class FedManCmdLineProcessor
         	.build();
 
 		Option logicalSecondArg = Option.builder()
-        	.longOpt( CMDLINEARG_LOGICAL_SECOND )
+        	.longOpt( CMDLINE_ARG_LOGICAL_SECOND )
 			.required( false )
 		    .desc( String.format( "Define a 'logical second'; the logical step size which " +
 		    					  "equates to a real-time second. " +
@@ -581,7 +1147,7 @@ public class FedManCmdLineProcessor
 		    .build();
 
 		Option logicalStepGranularityArg = Option.builder()
-        	.longOpt( CMDLINEARG_LOGICAL_STEP_GRANULARITY )
+        	.longOpt( CMDLINE_ARG_LOGICAL_STEP_GRANULARITY )
 			.required( false )
 		    .desc( String.format( "Define the number of steps per logical second. If " +
 		    				      "unspecified a value of %d will be used.",
@@ -590,7 +1156,7 @@ public class FedManCmdLineProcessor
 		    .build();
 
         Option realtimeMultiplierArg = Option.builder()
-        	.longOpt( CMDLINEARG_REALTIME_MULTIPLIER )
+        	.longOpt( CMDLINE_ARG_REALTIME_MULTIPLIER )
         	.required( false )
         	.desc( String.format( "Define the simulation rate. 1.0 is real time, 0.5 is " +
         						  "half speed, 2.0 is double speed, and so on. If unspecified " +
@@ -600,38 +1166,41 @@ public class FedManCmdLineProcessor
         	.build();
 
         Option noHttpSwitch = Option.builder()
-        	.longOpt( CMDLINEARG_NO_HTTP )
+        	.longOpt( CMDLINE_SWITCH_NO_HTTP_SERVICE )
         	.required( false )
         	.desc( String.format( "Turn off the HTTP service which provides REST-like endpoints " +
         						  "to control the Federation Manager. If unspecified " +
         						  "the HTTP service will be active (see also --%s).",
-        						  CMDLINEARG_HTTP_PORT) )
+        						  CMDLINE_ARG_HTTP_PORT) )
         	.build();
 
 		Option httpPortArg = Option.builder()
-        	.longOpt( CMDLINEARG_HTTP_PORT )
+        	.longOpt( CMDLINE_ARG_HTTP_PORT )
 			.hasArg()
         	.argName( "port" )
 			.required( false )
 		    .desc( String.format( "Specify the port to provide the HTTP service on. Only relevant if " +
 		    				      "the HTTP service is active (see also --%s). If unspecified, "+
 		    				      "port %d will be used.",
-		    				      CMDLINEARG_NO_HTTP, HTTP_PORT_DEFAULT ) )
+		    				      CMDLINE_SWITCH_NO_HTTP_SERVICE, HTTP_PORT_DEFAULT ) )
 			.type( PatternOptionBuilder.NUMBER_VALUE )
 		    .build();
-		
+
         Option configLocation = Option.builder()
-        	.longOpt( CMDLINEARG_CONFIG_FILE )
+        	.longOpt( CMDLINE_ARG_JSON_CONFIG_FILE )
 			.hasArg()
         	.argName( "file" )
-		    .desc( String.format( "Set the location of the configuration file for the Federation " +
-		    					  "Manager to use." ) )
+			.required( false )
+		    .desc( String.format( "Set the location of the JSON configuration file for the Federation " +
+		    					  "Manager to use. Values specified in this file will be overridden by " +
+		    					  "any corresponding command line argument values provided.") )
 			.type( PatternOptionBuilder.STRING_VALUE )
 		    .build();
-		
+
 		this.cmdLineOptions = new Options();
 
 		cmdLineOptions.addOption( help );
+		cmdLineOptions.addOption( configLocation );
 		cmdLineOptions.addOption( federationExecNameArg );
 		cmdLineOptions.addOption( federateNameArg );
 		cmdLineOptions.addOption( federateTypeArg );
@@ -642,7 +1211,6 @@ public class FedManCmdLineProcessor
 		cmdLineOptions.addOption( realtimeMultiplierArg );
 		cmdLineOptions.addOption( noHttpSwitch );
 		cmdLineOptions.addOption( httpPortArg );
-		cmdLineOptions.addOption( configLocation );
 
 		return cmdLineOptions;
 	}

--- a/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FederationManager.java
+++ b/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FederationManager.java
@@ -84,6 +84,18 @@ public class FederationManager
 			argProcessor.showHelp();
 			System.exit( 1 );
 		}
+		if( !argProcessor.hasFederationExecName() )
+		{
+			System.err.println( "ERROR: No federation execution name was specified." );
+			argProcessor.showHelp();
+			System.exit( 1 );
+		}
+		if( !argProcessor.hasStartRequirements() )
+		{
+			System.err.println( "ERROR: No federation start requirements were specified." );
+			argProcessor.showHelp();
+			System.exit( 1 );
+		}
 
 		try
 		{
@@ -99,7 +111,6 @@ public class FederationManager
 				String[] moduleFoms = { "fedman-fom.xml" };
 				config.addModules( urlsFromPaths(moduleFoms) );
 
-
 				// join modules
 				String[] joinModuleFoms = {};
 				config.addJoinModules( urlsFromPaths(joinModuleFoms) );
@@ -109,7 +120,7 @@ public class FederationManager
 				throw new UCEFException("Exception loading one of the FOM modules from disk", e);
 			}
 
-			if( argProcessor.withHttpService() )
+			if( argProcessor.withHttpServiceActive() )
 			{
 				httpServer = new FedManHttpServer( federate, argProcessor.httpServicePort() );
 				httpServer.startServer();
@@ -177,9 +188,9 @@ public class FederationManager
 		// config.setLookAhead( 0.25 );
 
 		// configure general federate configuration from command line args
+		config.setFederationName( argProcessor.federationExecName() );
 		config.setFederateName( argProcessor.federateName() );
 		config.setFederateType( argProcessor.federateType() );
-		config.setFederationName( argProcessor.federationExecName() );
 		config.setStepSize( argProcessor.logicalStepSize() );
 		config.setLookAhead( argProcessor.logicalStepSize() );
 

--- a/src/java/ucef-java-tools/src/main/resources/fedman-config.json
+++ b/src/java/ucef-java-tools/src/main/resources/fedman-config.json
@@ -1,6 +1,11 @@
 
 {
-    "federateName":          "FederationManager",
-    "federateType":          "FederationManager",
-    "federationExecName":    "ManagedFederation",
+    "federation-name":        "ManagedFederation",
+    "fedman-name":            "FederationManager",
+	"fedman-type":            "FederationManager",
+	"require":
+	[
+		{"type":"PingFederate", "count":1},
+		{"type":"PongFederate", "count":1}
+	]
 }


### PR DESCRIPTION
The federation manager has been updated so that it will now accept configuration from command line arguments and/or a JSON formatted configuration file.

The JSON configuration file is specified by the `--config` command line argument.

In the case that _both_ a configuration file and command line arguments are provided, the JSON configuration is loaded first, and then the command line args.

This means that it is possible to use a "standard" JSON configuration file as a starting point, and then override individual settings using command line arguments as required.

Note that:
- The keys in the JSON configuration file correspond to the command line arguments, so the mental overhead to switch between either configuration method is minimal.
- the startup requirements are provided in a JSON array containing JSON objects with `type` and `count` keys corresponding to federate type and required counts. For example: `[{"type":"ABCFederate","count":1},{"type":"XYZFederate","count":2}]` to require one `ABCFederate` and two `XYZFederate`s before allowing the simulation to start.
- any errors found in the JSON produce detailed explanatory error messages about the problem (in the same way that the command line arguments errors will) which should enable the user to correct the errors quickly.

Example JSON Config:
```json
{
    "fedman-name":            "FederationManager",
    "fedman-type":            "FederationManager",
    "federation-name":        "ManagedFederation",
    "require":
	[
		{"type": "ABCFederate", "count": 1},
		{"type": "XYZFederate", "count": 2}
	]
}
```