### PR TITLE
Updates to address some of Tom's Comments

### DIFF
--- a/src/java/ucef-java-core/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
+++ b/src/java/ucef-java-core/src/main/java/gov/nist/ucef/hla/base/FederateBase.java
@@ -596,8 +596,12 @@ public abstract class FederateBase
 			}
 			catch( UCEFException e )
 			{
-				logger.warn( "Failed to join federation '{}'",
-                             federationName );
+				logger.warn( "Failed to join federation '{}'", federationName );
+				if(logger.isDebugEnabled())
+				{
+					logger.debug( e.getLocalizedMessage() );
+					e.printStackTrace();
+				}
 				if( ++retryCount < maxRetries )
 					logger.warn( "Retrying in {} second{}...",
                                  retryInterval,
@@ -612,6 +616,9 @@ public abstract class FederateBase
                           federationName,
                           maxRetries,
                           (maxRetries == 1 ? "" : "s")  );
+			// if we can't join the federation, there is no point in 
+			// continuing at all - just exit now with non-zero exit code
+			System.exit( 1 );
 		}
 	}
 

--- a/src/java/ucef-java-genx-ping/run-ping-federate.sh
+++ b/src/java/ucef-java-genx-ping/run-ping-federate.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+JAVA_MAIN_CLASS="gov.nist.hla.genx.GenxPingFederate"
+HTTP_HOST=localhost
+HTTP_PORT=8888
+
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
+MVN=`which mvn`
+if [ -z "$MVN" ]
+then
+    echo "The `mvn` (Maven) application could not be found. Ensure it is installed and placed in your PATH."
+    exit
+fi
+
+CURL=`which curl`
+if [ -z "$CURL" ]
+then
+    echo "The `curl` application could not be found. Ensure it is installed and placed in your PATH."
+    exit
+fi
+
+
+CURL_RESPONSE=""
+while [ "$CURL_RESPONSE" != "true" ]
+do
+    # 'ping' the HTTP server on the federation manager
+    # to determine when it's a good time to start
+    CURL_RESPONSE=$($CURL -s http://$HTTP_HOST:$HTTP_PORT/query/is-waiting-for-federates/)
+    if [ "$CURL_RESPONSE" != "true" ]
+    then
+        echo "The Federation Manager does not seem to be ready yet..."
+        sleep 5s
+    fi
+done
+
+ARGS=$(join_by ' ' $@)
+$MVN exec:java -Dexec.mainClass="$JAVA_MAIN_CLASS" -Dexec.args="$ARGS"

--- a/src/java/ucef-java-tools/README.md
+++ b/src/java/ucef-java-tools/README.md
@@ -1,0 +1,180 @@
+# Overview
+
+This project contains tools for use in running federations.
+
+Currently the only tool is the "Federation Manager", which is detailed below.
+
+# Federation Manager
+
+The Federation Manager is actually just a UCEF federate whose purpose
+it is to...
+- initially *create* a federation (it is generally the only federate 
+  which should be allowed to do so)
+- monitor joining federates to determine whether that certain conditions
+  are met which will allow te start of a simulation run
+- control the stepping forward of time in the federation
+- issue `SimPause`, `SimResume` and `SimEnd` control interactions; well behaved
+  UCEF federates behave in accordance with this interaction signalling system.
+
+It also provides simple keyboard controls and a REST-like interface via a 
+basic HTTP service as control mechanisms.
+
+## Configuration
+
+The Federation Manager may be configured via the command line, a JSON formatted
+configuration file, or both.
+
+If specified, JSON configuration file content is processed first, and then any
+command line arguments supplied will act as overrides.
+
+This makes it possible to start with a "general" JSON configuration file, and
+tweak individual simulation runs with command line arguments as required.
+
+> **NOTE:** At a minumum, You *must* configure...
+ - a federation name and
+ - simulation start requirements
+   
+ ...to start the Federation Manager. If either of these are absent, the
+ Federation Manager will exit. 
+
+### Command Line Configuration
+
+ - `--config <file>` : Set the location of the JSON configuration file for the
+   Federation Manager to use. Values specified in this file will be overridden
+   by any corresponding command line argument values provided.
+ - `-r`,`--require <FEDERATE_TYPE,COUNT>`: Define required federate types
+   and minimum counts. For example, `-r FedABC,2` would require at least two 
+   'FedABC' type federates to join. Multiple requirements can be specified
+   by repeated use of this option.
+ - `-f`, `--federation-name <federation name>`: Set the name of the federation
+   the Federation Manager will join.
+ - `--fedman-name <federate name>`: Set the federate name for the Federation 
+   Manager to use. If unspecified a value of 'FederationManager' will be used.
+ - `--fedman-type <federate type>`: Set the federate type for the Federation
+   Manager to use. If unspecified a value of 'FederationManager' will be used.
+ - `--max-time <max>`: Set the maximum logical time to which the simulation 
+   may run. If unspecified the simulation will run indefinitely.
+ - `--logical-second`: Define a 'logical second'; the logical step size which
+   equates to a real-time second. If unspecified a value of 1.00 will be used.
+ - `--logical-granularity`: Define the number of steps per logical second. If 
+   unspecified a value of 1 will be used.
+ - `--realtime-multiplier`: Define the simulation rate. 1.0 is real time, 0.5
+   is half speed, 2.0 is double speed, and so on. If unspecified a value of
+   1.00 will be used.
+ - `--http-port <port>`: Specify the port to provide the HTTP service on. Only
+   relevant if the HTTP service is active (see also `--no-http-service`). If
+   unspecified, port 8888 will be used.
+ - `--no-http-service`: Turn off the HTTP service which provides REST-like 
+   endpoints to control the Federation Manager. If unspecified the HTTP
+   service will be active (see also `--http-port`).
+ - `-h`,`--help`: print help and usage text, and then exits
+
+The available command line arguments can be obtained using the `--help` or `-h`
+switch when starting the Federation Manager:
+
+-f PingPongFederation -r PingFederate,1 -r PongFederate,1  
+
+### JSON Configuration
+
+The JSON configuration keys are basically the "long" command line options with the
+leading `--` removed.
+
+The few exceptions are:
+ - the `help` option is not available in the JSON
+ - the `config` option is not available in the JSON
+ - rather than specificying multiple `require`ments as one would when using the 
+   command line, the JSON `require` option occurs just once, and expects a JSON
+   array consisting of JSON objects which have the following form: 
+   `{"type":FEDERATE_TYPE, "count": COUNT}`.
+ - the `no-http-service` switch is not available in the JSON. Instead use the
+   `http-service` key, which takes a boolean `true` or `false` as its value.
+ - The shortcut options (such as `r` for `require` and `f` for `federation-name`) may
+   not be used in the JSON configuration - only the "long" options may be used.
+
+Some other items of note:
+ - JSON recognizes text, numeric and boolean types.   
+    -- text items must be quoted  
+    -- numeric and boolean items must *not* be quoted  
+
+An example JSON configuration file content is shown below - all available options
+are exercised in this example:
+
+```json
+{
+    "fedman-name":            "FederationManager",
+    "fedman-type":            "FederationManager",
+    "federation-name":        "ManagedFederation",
+    "require":
+    [
+        {"type":"FederateABC", "count":1},
+        {"type":"FederateXYZ", "count":2}
+    ],
+    "max-time":            999999.0,
+    "logical-second":      1.0,
+    "logical-granularity": 1,
+    "realtime-multiplier": 1.0,
+    "http-service":        true,
+    "http-port":           8088
+}
+```
+
+## Keyboard Controls
+Once the start conditions have been met, the Federation Manager provides for simple
+keyboard control:
+
+ - pressing the `ENTER` key or `s` followed by `ENTER` will start the simulation
+ - pressing `p` or `SPACE` followed by the `ENTER` key once the simulation has started
+   will toggle pause/resume of the simulation.    
+ - pressing `x` or `q` followed by the `ENTER` key once the simulation has started
+   will end the simulation.    
+
+## REST-like HTTP Service
+By default, the Federation Manager will start a simple HTTP service on port 8888
+of the host running the Federation Manager.
+
+The port can be changed via the `http-port` option, and the service can be disabled
+entirely using the `no-http-service` command line switch, or specifying
+`"http-service":false` in the JSON configuration.
+
+Once the service has started, you can provide GET and POST requests to various
+endpoints to query state and issue commands for the Federation Manager.
+
+If you simply point a browser at port 8888 (or your `http-port` configured port),
+an web page will be displayed showing all available endpoints in a table, as well as 
+the types of request method(s) accepted by each endpoint.
+
+You can simply click on the endpoints in the table to GET or POST to them, 
+allowing Federation Manager to be queried and controlled directly from this
+web page.
+
+> **CAUTION:** There is no security or authentication applied here, so *anyone* can 
+ access this page, provided the network topology allows for it.
+
+Currently available endpoints are:
+
+ - `/ping` (GET)
+ - `/query/status` (GET)
+ - `/query/start-conditions` (GET)
+ - `/query/can-start` (GET)
+ - `/query/has-started` (GET)
+ - `/query/has-ended` (GET)
+ - `/query/is-paused` (GET)
+ - `/query/is-running` (GET)
+ - `/query/is-waiting-for-federates` (GET)
+ - `/command/start` (POST)
+ - `/command/pause` (POST)
+ - `/command/resume` (POST)
+ - `/command/end` (POST)
+
+The endpoints provide a simple "text only" response by default, apart from 
+`/query/start-conditions` wihch renders an HTML table showing the start 
+conditions and current status by default.
+
+Adding the query parameter `?json=true` will cause a richer, machine readable
+JSON response to be supplied, which may be more useful in some situations. For
+example...
+
+ - `/ping/`: `UCEF Federation Manager`
+ - `/ping/?json=true`: `{"path":"ping","response":"UCEF Federation Manager","query":{"json":"true"},"timestamp":1561100734100}`
+
+

--- a/src/java/ucef-java-tools/federation-manager.sh
+++ b/src/java/ucef-java-tools/federation-manager.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
+MVN=`which mvn`
+
+if [ -z "$MVN" ]
+then
+    echo "The `mvn` (Maven) application could not be found. Ensure it is installed and placed in your PATH."
+    exit
+else
+    ARGS=$(join_by ' ' $@)
+    $MVN exec:java -Dexec.mainClass="gov.nist.ucef.hla.tools.fedman.FederationManager" -Dexec.args="$ARGS"
+fi

--- a/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManCmdLineProcessor.java
+++ b/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManCmdLineProcessor.java
@@ -83,7 +83,7 @@ public class FedManCmdLineProcessor
 	private static final int LOGICAL_STEP_GRANULARITY_DEFAULT          = 1;
 	private static final double REALTIME_MULTIPLIER_DEFAULT            = 1.0;
 	private static final boolean HTTP_SERVICE_ACTIVE_DEFAULT           = true;
-	private static final int HTTP_PORT_DEFAULT                         = 8080;
+	private static final int HTTP_PORT_DEFAULT                         = 8888;
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -433,7 +433,10 @@ public class FedManCmdLineProcessor
 					CMDLINE_ARG_LOGICAL_SECOND,
 					CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
 					CMDLINE_ARG_REALTIME_MULTIPLIER,
-					CMDLINE_SWITCH_NO_HTTP_SERVICE,
+					// note that the JSON is slightly different to command line here
+					// since it can accept true or false for HTTP service activation
+					// - compare with CMDLINE_SWITCH_NO_HTTP_SERVICE
+					JSON_CONFIG_KEY_WITH_HTTP,
 					CMDLINE_ARG_HTTP_PORT
 				}
 			));

--- a/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManCmdLineProcessor.java
+++ b/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FedManCmdLineProcessor.java
@@ -276,18 +276,19 @@ public class FedManCmdLineProcessor
         // optional arguments
         this.federateName = extractCmdLineString( cmdLine,
                                            CMDLINE_ARG_FEDMAN_FEDERATE_NAME,
-                                           FEDMAN_FEDERATE_NAME_DEFAULT );
+                                           this.federateName );
         this.federateType = extractCmdLineString( cmdLine,
                                            CMDLINE_ARG_FEDMAN_FEDERATE_TYPE,
-                                           FEDMAN_FEDERATE_TYPE_DEFAULT );
+                                           this.federateType );
 
         // NOTE that this is a bit of a double negative - the lack of the
         //      no-http switch means that withHttpService is true.
-        this.withHttpServiceActive = !cmdLine.hasOption( CMDLINE_SWITCH_NO_HTTP_SERVICE );
+        if(this.withHttpServiceActive)
+        	this.withHttpServiceActive = !cmdLine.hasOption( CMDLINE_SWITCH_NO_HTTP_SERVICE );
         this.httpServicePort = extractCmdLineInRangeInt( cmdLine,
                                                   CMDLINE_ARG_HTTP_PORT,
                                                   0, 65535,
-                                                  HTTP_PORT_DEFAULT );
+                                                  this.httpServicePort );
 
         // we need to sanity check some arguments with respect to each other
         // to ensure that they are "sensible" - in other words, the values
@@ -295,16 +296,16 @@ public class FedManCmdLineProcessor
         // some problems
         this.maxTime = extractCmdLineGtZeroDouble( cmdLine,
                                             CMDLINE_ARG_MAX_TIME,
-                                            MAX_TIME_DEFAULT );
+                                            this.maxTime );
 		this.logicalSecond = extractCmdLineGtZeroDouble( cmdLine,
 		                                          CMDLINE_ARG_LOGICAL_SECOND,
-		                                          LOGICAL_SECOND_DEFAULT );
+		                                          this.logicalSecond );
 		this.logicalStepGranularity = extractCmdLineGtZeroInt( cmdLine,
 		                                                CMDLINE_ARG_LOGICAL_STEP_GRANULARITY,
-		                                                LOGICAL_STEP_GRANULARITY_DEFAULT );
+		                                                this.logicalStepGranularity );
 		this.realtimeMultiplier = extractCmdLineGtZeroDouble( cmdLine,
 		                                               CMDLINE_ARG_REALTIME_MULTIPLIER,
-		                                               REALTIME_MULTIPLIER_DEFAULT );
+		                                               this.realtimeMultiplier );
 
 		double oneSecond = 1000.0 / this.realtimeMultiplier;
 		double logicalStepSize = logicalSecond / logicalStepGranularity;
@@ -741,7 +742,7 @@ public class FedManCmdLineProcessor
 			if( value instanceof Boolean )
 			{
 				if(logger.isDebugEnabled())
-					logger.debug( String.format( "Found value '%s' for item '%s' in configuration file", value, key ) );
+					logger.debug( String.format( "Found value %s for item '%s' in configuration file", value, key ) );
 
 				return (Boolean)value;
 			}

--- a/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FederationManager.java
+++ b/src/java/ucef-java-tools/src/main/java/gov/nist/ucef/hla/tools/fedman/FederationManager.java
@@ -31,6 +31,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import gov.nist.ucef.hla.base.FederateConfiguration;
 import gov.nist.ucef.hla.base.Types.DataType;
@@ -63,6 +65,7 @@ public class FederationManager
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
+	private static final Logger logger = LogManager.getLogger( FederationManager.class );
 
 	//----------------------------------------------------------
 	//                     STATIC METHODS
@@ -102,8 +105,6 @@ public class FederationManager
 			FedManFederate federate = new FedManFederate();
 			initializeConfig( federate, argProcessor );
 
-			// TODO!!!!!!!!!!
-			// This all needs to be shifted into the config initialization
 			try
 			{
 				FederateConfiguration config = federate.getFederateConfiguration();
@@ -124,6 +125,10 @@ public class FederationManager
 			{
 				httpServer = new FedManHttpServer( federate, argProcessor.httpServicePort() );
 				httpServer.startServer();
+			}
+			else
+			{
+				logger.info( "HTTP service disabled by config. Skipping HTTP service startup." );
 			}
 
 			federate.runFederate();

--- a/src/java/ucef-java-tools/src/main/resources/fedman-config.json
+++ b/src/java/ucef-java-tools/src/main/resources/fedman-config.json
@@ -7,5 +7,11 @@
 	[
 		{"type":"PingFederate", "count":1},
 		{"type":"PongFederate", "count":1}
-	]
+	],
+	"max-time": 999999.0,
+	"logical-second": 1.0,
+	"logical-granularity": 1,
+	"realtime-multiplier": 1.0,
+	"http-service": true,
+	"http-port": 8088
 }


### PR DESCRIPTION
Main changes:
- Updates to most README documents
- Added 'full' example of all options available in JSON configuration (and associated README update)
- Fixed an issue where JSON config options with would be overridden with defaults if a command line option was not specified
- changed default port of HTTP server to `8888` (from `8088`)
- new README for Federation Manager
- bash shell scripts to start Federation Manager and Genx Ping/Pong federates for *nix users

Other changes:
- switched to `simplejson` framework rather than custom code for JSON encoding of responses to HTTP requests
- update to Federation Manager HTTP server 404 "index" page to allow POSTs to endpoints requiring a POST
- extra INFO level logging to indicate that the Federation Manager HTTP server is not active (due to a configuration option turning it off)
- extra DEBUG level logging for exceptions encountered while attempting to join a federation
